### PR TITLE
Enable noop to enable dead connection detection

### DIFF
--- a/src/main/java/com/couchbase/connect/kafka/CouchbaseReader.java
+++ b/src/main/java/com/couchbase/connect/kafka/CouchbaseReader.java
@@ -66,6 +66,7 @@ public class CouchbaseReader extends Thread {
                 .username(username)
                 .password(password)
                 .controlParam(DcpControl.Names.CONNECTION_BUFFER_SIZE, 20480)
+                .controlParam(DcpControl.Names.ENABLE_NOOP, "true")
                 .bufferAckWatermark(60)
                 .sslEnabled(sslEnabled)
                 .sslKeystoreFile(sslKeystoreLocation)


### PR DESCRIPTION
When we leave Couchbase idle for ~20 minutes, the DCP connection gets dropped by Couchbase, but the connector doesn't detect that it's no longer connected. Enabling noop appears to fix the problem by keeping the connection alive, and it doesn't seem there is any obvious reason why you wouldn't always want to run with noop enabled.