### PR TITLE
Addition of subdocument and N1QL mode to Couchbase Sink Connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -293,7 +293,7 @@
         </resources>
     </build>
 
-    <!--<profiles>
+    <profiles>
         <profile>
             <id>release</id>
             <properties>
@@ -307,5 +307,5 @@
                 <gpg.skip>false</gpg.skip>
             </properties>
         </profile>
-    </profiles>-->
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
         <junit.version>4.12</junit.version>
         <mysql.version>5.1.6</mysql.version>
+        <mockito.version>1.10.19</mockito.version>
         <dist-archive-name>${project.artifactId}-${project.version}.zip</dist-archive-name>
 
         <!-- Don't sign artifacts unless the 'stage' or 'release' profile is active -->
@@ -139,11 +140,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
             <version>${mysql.version}</version>
             <scope>test</scope>
         </dependency>
+
     </dependencies>
 
     <build>
@@ -285,7 +293,7 @@
         </resources>
     </build>
 
-    <profiles>
+    <!--<profiles>
         <profile>
             <id>release</id>
             <properties>
@@ -299,5 +307,5 @@
                 <gpg.skip>false</gpg.skip>
             </properties>
         </profile>
-    </profiles>
+    </profiles>-->
 </project>

--- a/src/main/java/com/couchbase/connect/kafka/CouchbaseSinkConnectorConfig.java
+++ b/src/main/java/com/couchbase/connect/kafka/CouchbaseSinkConnectorConfig.java
@@ -19,6 +19,8 @@ package com.couchbase.connect.kafka;
 import com.couchbase.client.core.logging.RedactionLevel;
 import com.couchbase.client.java.PersistTo;
 import com.couchbase.client.java.ReplicateTo;
+import com.couchbase.connect.kafka.sink.DocumentMode;
+import com.couchbase.connect.kafka.sink.SubDocumentMode;
 import com.couchbase.connect.kafka.util.config.BooleanParentRecommender;
 import com.couchbase.connect.kafka.util.config.EnumRecommender;
 import com.couchbase.connect.kafka.util.config.EnumValidator;
@@ -79,6 +81,21 @@ public class CouchbaseSinkConnectorConfig extends AbstractConfig {
     static final String DOCUMENT_PATH_DOC = "JSON Pointer to the property to use as the root for the Couchbase sub-document operation.";
     static final String DOCUMENT_PATH_DISPLAY = "Document Path";
     public static final String DOCUMENT_PATH_DEFAULT = "";
+
+    public static final String DOCUMENT_MODE_CONFIG = "couchbase.document.mode";
+    static final String DOCUMENT_MODE_DOC = "Setting to indicate an update to the entire document or a sub-document";
+    static final String DOCUMENT_MODE_DISPLAY = "Document Mode";
+    public static final String DOCUMENT_MODE_DEFAULT = DocumentMode.DOCUMENT.name();
+
+    public static final String SUBDOCUMENT_MODE_CONFIG = "couchbase.subdocument.mode";
+    static final String SUBDOCUMENT_MODE_DOC = "Setting to indicate the type of update to a sub-document";
+    static final String SUBDOCUMENT_MODE_DISPLAY = "Sub-Document Mode";
+    public static final String SUBDOCUMENT_MODE_DEFAULT = SubDocumentMode.UPSERT.name();
+
+    public static final String SUBDOCUMENT_CREATEPATH_CONFIG = "couchbase.subdocument.createpath";
+    static final String SUBDOCUMENT_CREATEPATH_DOC = "Whether to add the parent paths if they are missing in the document";
+    static final String SUBDOCUMENT_CREATEPATH_DISPLAY = "Create parent paths";
+    public static final boolean SUBDOCUMENT_CREATEPATH_DEFAULT = true;
 
     public static final String REMOVE_DOCUMENT_ID_CONFIG = "couchbase.remove.document.id";
     static final String REMOVE_DOCUMENT_ID_DOC = "Whether to remove the ID identified by '" + DOCUMENT_ID_POINTER_CONFIG + "' from the document before storing in Couchbase.";
@@ -254,6 +271,37 @@ public class CouchbaseSinkConnectorConfig extends AbstractConfig {
                         ConfigDef.Width.LONG,
                         DOCUMENT_PATH_DISPLAY,
                         Collections.singletonList(DOCUMENT_PATH_CONFIG))
+
+                .define(DOCUMENT_MODE_CONFIG,
+                        ConfigDef.Type.STRING,
+                        DOCUMENT_MODE_DEFAULT,
+                        new EnumValidator(DocumentMode.class),
+                        ConfigDef.Importance.LOW,
+                        DOCUMENT_MODE_DOC,
+                        DATABASE_GROUP, 15,
+                        ConfigDef.Width.LONG,
+                        DOCUMENT_MODE_DISPLAY,
+                        new EnumRecommender(DocumentMode.class))
+
+                .define(SUBDOCUMENT_MODE_CONFIG,
+                        ConfigDef.Type.STRING,
+                        SUBDOCUMENT_MODE_DEFAULT,
+                        new EnumValidator(SubDocumentMode.class),
+                        ConfigDef.Importance.LOW,
+                        SUBDOCUMENT_MODE_DOC,
+                        DATABASE_GROUP, 16,
+                        ConfigDef.Width.LONG,
+                        SUBDOCUMENT_MODE_DISPLAY,
+                        new EnumRecommender(SubDocumentMode.class))
+
+                .define(SUBDOCUMENT_CREATEPATH_CONFIG,
+                        ConfigDef.Type.BOOLEAN,
+                        SUBDOCUMENT_CREATEPATH_DEFAULT,
+                        ConfigDef.Importance.LOW,
+                        SUBDOCUMENT_CREATEPATH_DOC,
+                        DATABASE_GROUP, 17,
+                        ConfigDef.Width.LONG,
+                        SUBDOCUMENT_CREATEPATH_DISPLAY)
 
                 ;
     }

--- a/src/main/java/com/couchbase/connect/kafka/CouchbaseSinkConnectorConfig.java
+++ b/src/main/java/com/couchbase/connect/kafka/CouchbaseSinkConnectorConfig.java
@@ -77,10 +77,10 @@ public class CouchbaseSinkConnectorConfig extends AbstractConfig {
     static final String DOCUMENT_ID_POINTER_DISPLAY = "Document ID Pointer";
     public static final String DOCUMENT_ID_POINTER_DEFAULT = "";
 
-    public static final String DOCUMENT_PATH_CONFIG = "couchbase.document.path";
-    static final String DOCUMENT_PATH_DOC = "JSON Pointer to the property to use as the root for the Couchbase sub-document operation.";
-    static final String DOCUMENT_PATH_DISPLAY = "Document Path";
-    public static final String DOCUMENT_PATH_DEFAULT = "";
+    public static final String SUBDOCUMENT_PATH_CONFIG = "couchbase.subdocument.path";
+    static final String SUBDOCUMENT_PATH_DOC = "JSON Pointer to the property to use as the root for the Couchbase sub-document operation.";
+    static final String SUBDOCUMENT_PATH_DISPLAY = "Document Path";
+    public static final String SUBDOCUMENT_PATH_DEFAULT = "";
 
     public static final String DOCUMENT_MODE_CONFIG = "couchbase.document.mode";
     static final String DOCUMENT_MODE_DOC = "Setting to indicate an update to the entire document or a sub-document";
@@ -96,6 +96,12 @@ public class CouchbaseSinkConnectorConfig extends AbstractConfig {
     static final String SUBDOCUMENT_CREATEPATH_DOC = "Whether to add the parent paths if they are missing in the document";
     static final String SUBDOCUMENT_CREATEPATH_DISPLAY = "Create parent paths";
     public static final boolean SUBDOCUMENT_CREATEPATH_DEFAULT = true;
+
+    public static final String SUBDOCUMENT_CREATEDOCUMENT_CONFIG = "couchbase.subdocument.createdocument";
+    static final String SUBDOCUMENT_CREATEDOCUMENT_DOC = "Whether to create the document if it does not exist";
+    static final String SUBDOCUMENT_CREATEDOCUMENT_DISPLAY = "Create parent document";
+    public static final boolean SUBDOCUMENT_CREATEDOCUMENT_DEFAULT = true;
+
 
     public static final String REMOVE_DOCUMENT_ID_CONFIG = "couchbase.remove.document.id";
     static final String REMOVE_DOCUMENT_ID_DOC = "Whether to remove the ID identified by '" + DOCUMENT_ID_POINTER_CONFIG + "' from the document before storing in Couchbase.";
@@ -262,15 +268,15 @@ public class CouchbaseSinkConnectorConfig extends AbstractConfig {
                         LOG_REDACTION_DISPLAY,
                         new EnumRecommender(RedactionLevel.class))
 
-                .define(DOCUMENT_PATH_CONFIG,
+                .define(SUBDOCUMENT_PATH_CONFIG,
                         ConfigDef.Type.STRING,
-                        DOCUMENT_PATH_DEFAULT,
+                        SUBDOCUMENT_PATH_DEFAULT,
                         ConfigDef.Importance.LOW,
-                        DOCUMENT_PATH_DOC,
+                        SUBDOCUMENT_PATH_DOC,
                         DATABASE_GROUP, 14,
                         ConfigDef.Width.LONG,
-                        DOCUMENT_PATH_DISPLAY,
-                        Collections.singletonList(DOCUMENT_PATH_CONFIG))
+                        SUBDOCUMENT_PATH_DISPLAY,
+                        Collections.singletonList(SUBDOCUMENT_PATH_CONFIG))
 
                 .define(DOCUMENT_MODE_CONFIG,
                         ConfigDef.Type.STRING,
@@ -302,6 +308,15 @@ public class CouchbaseSinkConnectorConfig extends AbstractConfig {
                         DATABASE_GROUP, 17,
                         ConfigDef.Width.LONG,
                         SUBDOCUMENT_CREATEPATH_DISPLAY)
+
+                .define(SUBDOCUMENT_CREATEDOCUMENT_CONFIG,
+                        ConfigDef.Type.BOOLEAN,
+                        SUBDOCUMENT_CREATEDOCUMENT_DEFAULT,
+                        ConfigDef.Importance.LOW,
+                        SUBDOCUMENT_CREATEDOCUMENT_DOC,
+                        DATABASE_GROUP, 17,
+                        ConfigDef.Width.LONG,
+                        SUBDOCUMENT_CREATEDOCUMENT_DISPLAY)
 
                 ;
     }

--- a/src/main/java/com/couchbase/connect/kafka/CouchbaseSinkConnectorConfig.java
+++ b/src/main/java/com/couchbase/connect/kafka/CouchbaseSinkConnectorConfig.java
@@ -20,6 +20,7 @@ import com.couchbase.client.core.logging.RedactionLevel;
 import com.couchbase.client.java.PersistTo;
 import com.couchbase.client.java.ReplicateTo;
 import com.couchbase.connect.kafka.sink.DocumentMode;
+import com.couchbase.connect.kafka.sink.N1qlMode;
 import com.couchbase.connect.kafka.sink.SubDocumentMode;
 import com.couchbase.connect.kafka.util.config.BooleanParentRecommender;
 import com.couchbase.connect.kafka.util.config.EnumRecommender;
@@ -91,6 +92,11 @@ public class CouchbaseSinkConnectorConfig extends AbstractConfig {
     static final String SUBDOCUMENT_MODE_DOC = "Setting to indicate the type of update to a sub-document";
     static final String SUBDOCUMENT_MODE_DISPLAY = "Sub-Document Mode";
     public static final String SUBDOCUMENT_MODE_DEFAULT = SubDocumentMode.UPSERT.name();
+
+    public static final String N1QL_MODE_CONFIG = "couchbase.n1ql.mode";
+    static final String N1QL_MODE_DOC = "Setting to indicate the type of update ";
+    static final String N1QL_MODE_DISPLAY = "N1QL Mode";
+    public static final String N1QL_MODE_DEFAULT = N1qlMode.UPSERT.name();
 
     public static final String SUBDOCUMENT_CREATEPATH_CONFIG = "couchbase.subdocument.createpath";
     static final String SUBDOCUMENT_CREATEPATH_DOC = "Whether to add the parent paths if they are missing in the document";
@@ -300,12 +306,23 @@ public class CouchbaseSinkConnectorConfig extends AbstractConfig {
                         SUBDOCUMENT_MODE_DISPLAY,
                         new EnumRecommender(SubDocumentMode.class))
 
+                .define(N1QL_MODE_CONFIG,
+                        ConfigDef.Type.STRING,
+                        N1QL_MODE_DEFAULT,
+                        new EnumValidator(N1qlMode.class),
+                        ConfigDef.Importance.LOW,
+                        N1QL_MODE_DOC,
+                        DATABASE_GROUP, 17,
+                        ConfigDef.Width.LONG,
+                        N1QL_MODE_DISPLAY,
+                        new EnumRecommender(N1qlMode.class))
+
                 .define(SUBDOCUMENT_CREATEPATH_CONFIG,
                         ConfigDef.Type.BOOLEAN,
                         SUBDOCUMENT_CREATEPATH_DEFAULT,
                         ConfigDef.Importance.LOW,
                         SUBDOCUMENT_CREATEPATH_DOC,
-                        DATABASE_GROUP, 17,
+                        DATABASE_GROUP, 18,
                         ConfigDef.Width.LONG,
                         SUBDOCUMENT_CREATEPATH_DISPLAY)
 
@@ -314,7 +331,7 @@ public class CouchbaseSinkConnectorConfig extends AbstractConfig {
                         SUBDOCUMENT_CREATEDOCUMENT_DEFAULT,
                         ConfigDef.Importance.LOW,
                         SUBDOCUMENT_CREATEDOCUMENT_DOC,
-                        DATABASE_GROUP, 17,
+                        DATABASE_GROUP, 19,
                         ConfigDef.Width.LONG,
                         SUBDOCUMENT_CREATEDOCUMENT_DISPLAY)
 

--- a/src/main/java/com/couchbase/connect/kafka/CouchbaseSinkConnectorConfig.java
+++ b/src/main/java/com/couchbase/connect/kafka/CouchbaseSinkConnectorConfig.java
@@ -75,6 +75,11 @@ public class CouchbaseSinkConnectorConfig extends AbstractConfig {
     static final String DOCUMENT_ID_POINTER_DISPLAY = "Document ID Pointer";
     public static final String DOCUMENT_ID_POINTER_DEFAULT = "";
 
+    public static final String DOCUMENT_PATH_CONFIG = "couchbase.document.path";
+    static final String DOCUMENT_PATH_DOC = "JSON Pointer to the property to use as the root for the Couchbase sub-document operation.";
+    static final String DOCUMENT_PATH_DISPLAY = "Document Path";
+    public static final String DOCUMENT_PATH_DEFAULT = "";
+
     public static final String REMOVE_DOCUMENT_ID_CONFIG = "couchbase.remove.document.id";
     static final String REMOVE_DOCUMENT_ID_DOC = "Whether to remove the ID identified by '" + DOCUMENT_ID_POINTER_CONFIG + "' from the document before storing in Couchbase.";
     static final String REMOVE_DOCUMENT_ID_DISPLAY = "Remove Document ID";
@@ -239,6 +244,17 @@ public class CouchbaseSinkConnectorConfig extends AbstractConfig {
                         ConfigDef.Width.LONG,
                         LOG_REDACTION_DISPLAY,
                         new EnumRecommender(RedactionLevel.class))
+
+                .define(DOCUMENT_PATH_CONFIG,
+                        ConfigDef.Type.STRING,
+                        DOCUMENT_PATH_DEFAULT,
+                        ConfigDef.Importance.LOW,
+                        DOCUMENT_PATH_DOC,
+                        DATABASE_GROUP, 14,
+                        ConfigDef.Width.LONG,
+                        DOCUMENT_PATH_DISPLAY,
+                        Collections.singletonList(DOCUMENT_PATH_CONFIG))
+
                 ;
     }
 

--- a/src/main/java/com/couchbase/connect/kafka/sink/DocumentMode.java
+++ b/src/main/java/com/couchbase/connect/kafka/sink/DocumentMode.java
@@ -1,0 +1,16 @@
+package com.couchbase.connect.kafka.sink;
+
+public enum DocumentMode {
+    DOCUMENT("document"),
+    SUBDOCUMENT("subdocument");
+
+    private final String schemaName;
+
+    DocumentMode(String schemaName) {
+        this.schemaName = schemaName;
+    }
+
+    public String schemaName() {
+        return schemaName;
+    }
+}

--- a/src/main/java/com/couchbase/connect/kafka/sink/N1qlMode.java
+++ b/src/main/java/com/couchbase/connect/kafka/sink/N1qlMode.java
@@ -1,13 +1,13 @@
 package com.couchbase.connect.kafka.sink;
 
-public enum DocumentMode {
-    DOCUMENT("document"),
-    SUBDOCUMENT("subdocument"),
-    N1QL("n1ql");
+public enum N1qlMode {
+    UPDATE("update"),
+    UPSERT("upsert");
+
 
     private final String schemaName;
 
-    DocumentMode(String schemaName) {
+    N1qlMode(String schemaName) {
         this.schemaName = schemaName;
     }
 

--- a/src/main/java/com/couchbase/connect/kafka/sink/N1qlMode.java
+++ b/src/main/java/com/couchbase/connect/kafka/sink/N1qlMode.java
@@ -1,17 +1,6 @@
 package com.couchbase.connect.kafka.sink;
 
 public enum N1qlMode {
-    UPDATE("update"),
-    UPSERT("upsert");
-
-
-    private final String schemaName;
-
-    N1qlMode(String schemaName) {
-        this.schemaName = schemaName;
-    }
-
-    public String schemaName() {
-        return schemaName;
-    }
+    UPDATE,
+    UPSERT;
 }

--- a/src/main/java/com/couchbase/connect/kafka/sink/N1qlWriter.java
+++ b/src/main/java/com/couchbase/connect/kafka/sink/N1qlWriter.java
@@ -1,0 +1,112 @@
+package com.couchbase.connect.kafka.sink;
+
+import com.couchbase.client.java.AsyncBucket;
+import com.couchbase.client.java.PersistTo;
+import com.couchbase.client.java.ReplicateTo;
+import com.couchbase.client.java.document.json.JsonObject;
+import com.couchbase.client.java.query.AsyncN1qlQueryResult;
+import com.couchbase.client.java.query.N1qlQuery;
+import com.couchbase.connect.kafka.util.JsonBinaryDocument;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import rx.Completable;
+import rx.Notification;
+import rx.functions.Action1;
+
+import static com.couchbase.client.deps.io.netty.util.CharsetUtil.UTF_8;
+
+public class N1qlWriter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(N1qlWriter.class);
+
+    private N1qlMode mode;
+
+    private boolean createDocuments;
+
+    public N1qlWriter(N1qlMode mode, boolean createDocuments){
+        this.mode = mode;
+        this.createDocuments = createDocuments;
+    }
+
+    public Completable write(final AsyncBucket bucket, final JsonBinaryDocument document, PersistTo persistTo, ReplicateTo replicateTo) {
+        if(document == null || document.content() == null){
+            LOGGER.warn("document or document content is null");
+            // skip it
+            return Completable.complete();
+        }
+
+        final JsonObject node = JsonObject.fromJson(document.content().toString(UTF_8));
+
+        N1qlQuery query = null;
+        if(this.mode == N1qlMode.UPDATE){
+            String statement = parseUpdate(bucket.name(), document.id(), node);
+
+            if(statement == null || statement.isEmpty()) {
+                LOGGER.warn("could not generate statement from node "+node.toString());
+                return Completable.complete();
+            }
+
+            query = N1qlQuery.parameterized(statement,node);
+        }
+        if(this.mode ==N1qlMode.UPSERT){
+            String statement = parseUpsert(bucket.name(), document.id(), node);
+            if(statement == null || statement.isEmpty()) {
+                LOGGER.warn("could not generate statement from node "+node.toString());
+                return Completable.complete();
+            }
+
+            query = N1qlQuery.simple(statement);
+        }
+
+        return bucket.query(query)
+                .doOnEach(new Action1<Notification<? super AsyncN1qlQueryResult>>() {
+                    @Override
+                    public void call(Notification<? super AsyncN1qlQueryResult> notification) {
+                        if(mode == N1qlMode.UPDATE && createDocuments) {
+                            AsyncN1qlQueryResult result = (AsyncN1qlQueryResult) notification.getValue();
+                            if (result != null && result.rows().count().toBlocking().single() == 0) {
+                                String statement = parseUpsert(bucket.name(), document.id(), node);
+                                if (statement == null || statement.isEmpty()) {
+                                    LOGGER.warn("could not generate statement from node " + node.toString());
+                                }
+
+                                bucket.query(N1qlQuery.simple(statement)).toBlocking().single();
+                            }
+                        }
+                    }
+                })
+                .toCompletable();
+    }
+
+    private String parseUpdate(String keySpace, String id, JsonObject values) {
+        if(values == null || values.equals(JsonObject.empty()))  {
+            return null;
+        }
+
+        StringBuilder statement = new StringBuilder();
+        statement.append(String.format("UPDATE `%s` USE KEYS \"%s\" SET ",keySpace,id));
+
+        for(String name : values.getNames()){
+            statement.append(String.format("%s = $%s, ",name,name));
+        }
+
+        String result = statement.toString();
+        return String.format("%s %s",result.substring(0, result.length() - 2),"RETURNING meta().id;");
+    }
+
+    private String parseUpsert(String keySpace, String id, JsonObject values) {
+        if(values == null || values.equals(JsonObject.empty()))  {
+            return null;
+        }
+
+        StringBuilder statement = new StringBuilder();
+        statement.append(String.format("UPSERT INTO `%s` (KEY,VALUE) VALUES (\"%s\", ",keySpace,id));
+
+        statement.append(values.toString());
+        statement.append(") RETURNING meta().id;");
+
+        return statement.toString();
+    }
+}

--- a/src/main/java/com/couchbase/connect/kafka/sink/N1qlWriter.java
+++ b/src/main/java/com/couchbase/connect/kafka/sink/N1qlWriter.java
@@ -23,15 +23,17 @@ public class N1qlWriter {
 
     private N1qlMode mode;
 
+    private String idField = "__id__";
+
     private boolean createDocuments;
 
-    public N1qlWriter(N1qlMode mode, boolean createDocuments){
+    public N1qlWriter(N1qlMode mode, boolean createDocuments) {
         this.mode = mode;
         this.createDocuments = createDocuments;
     }
 
     public Completable write(final AsyncBucket bucket, final JsonBinaryDocument document, PersistTo persistTo, ReplicateTo replicateTo) {
-        if(document == null || document.content() == null){
+        if (document == null || document.content() == null) {
             LOGGER.warn("document or document content is null");
             // skip it
             return Completable.complete();
@@ -40,34 +42,36 @@ public class N1qlWriter {
         final JsonObject node = JsonObject.fromJson(document.content().toString(UTF_8));
 
         N1qlQuery query = null;
-        if(this.mode == N1qlMode.UPDATE){
-            String statement = parseUpdate(bucket.name(), document.id(), node);
+        if (this.mode == N1qlMode.UPDATE) {
+            String statement = parseUpdate(bucket.name(), node);
 
-            if(statement == null || statement.isEmpty()) {
-                LOGGER.warn("could not generate statement from node "+node.toString());
+            if (statement == null || statement.isEmpty()) {
+                LOGGER.warn("could not generate statement from node " + node.toString());
                 return Completable.complete();
             }
 
-            query = N1qlQuery.parameterized(statement,node);
+            node.put(idField, document.id());
+            query = N1qlQuery.parameterized(statement, node);
         }
-        if(this.mode ==N1qlMode.UPSERT){
-            String statement = parseUpsert(bucket.name(), document.id(), node);
-            if(statement == null || statement.isEmpty()) {
-                LOGGER.warn("could not generate statement from node "+node.toString());
+        if (this.mode == N1qlMode.UPSERT) {
+            String statement = parseUpsert(bucket.name(), node);
+            if (statement == null || statement.isEmpty()) {
+                LOGGER.warn("could not generate statement from node " + node.toString());
                 return Completable.complete();
             }
 
-            query = N1qlQuery.simple(statement);
+            JsonObject idObject = JsonObject.empty().put(idField, document.id());
+            query = N1qlQuery.parameterized(statement, idObject);
         }
 
         return bucket.query(query)
                 .doOnEach(new Action1<Notification<? super AsyncN1qlQueryResult>>() {
                     @Override
                     public void call(Notification<? super AsyncN1qlQueryResult> notification) {
-                        if(mode == N1qlMode.UPDATE && createDocuments) {
+                        if (mode == N1qlMode.UPDATE && createDocuments) {
                             AsyncN1qlQueryResult result = (AsyncN1qlQueryResult) notification.getValue();
                             if (result != null && result.rows().count().toBlocking().single() == 0) {
-                                String statement = parseUpsert(bucket.name(), document.id(), node);
+                                String statement = parseUpsert(bucket.name(), node);
                                 if (statement == null || statement.isEmpty()) {
                                     LOGGER.warn("could not generate statement from node " + node.toString());
                                 }
@@ -80,29 +84,29 @@ public class N1qlWriter {
                 .toCompletable();
     }
 
-    private String parseUpdate(String keySpace, String id, JsonObject values) {
-        if(values == null || values.equals(JsonObject.empty()))  {
+    private String parseUpdate(String keySpace, JsonObject values) {
+        if (values == null || values.equals(JsonObject.empty())) {
             return null;
         }
 
         StringBuilder statement = new StringBuilder();
-        statement.append(String.format("UPDATE `%s` USE KEYS \"%s\" SET ",keySpace,id));
+        statement.append(String.format("UPDATE `%s` USE KEYS $%s SET ", keySpace, idField));
 
-        for(String name : values.getNames()){
-            statement.append(String.format("%s = $%s, ",name,name));
+        for (String name : values.getNames()) {
+            statement.append(String.format("%s = $%s, ", name, name));
         }
 
         String result = statement.toString();
-        return String.format("%s %s",result.substring(0, result.length() - 2),"RETURNING meta().id;");
+        return result.substring(0, result.length() - 2) + " RETURNING meta().id;";
     }
 
-    private String parseUpsert(String keySpace, String id, JsonObject values) {
-        if(values == null || values.equals(JsonObject.empty()))  {
+    private String parseUpsert(String keySpace, JsonObject values) {
+        if (values == null || values.equals(JsonObject.empty())) {
             return null;
         }
 
         StringBuilder statement = new StringBuilder();
-        statement.append(String.format("UPSERT INTO `%s` (KEY,VALUE) VALUES (\"%s\", ",keySpace,id));
+        statement.append(String.format("UPSERT INTO `%s` (KEY,VALUE) VALUES ($%s, ", keySpace, idField));
 
         statement.append(values.toString());
         statement.append(") RETURNING meta().id;");

--- a/src/main/java/com/couchbase/connect/kafka/sink/SubDocumentMode.java
+++ b/src/main/java/com/couchbase/connect/kafka/sink/SubDocumentMode.java
@@ -1,0 +1,24 @@
+package com.couchbase.connect.kafka.sink;
+
+public enum SubDocumentMode {
+    UPSERT("upsert"),
+    MERGE("merge"),
+    ARRAYINSERT("arrayInsert"),
+    ARRAYPREPEND("arrayPrepend"),
+    ARRAYAPPEND("arrayAppend"),
+    ARRAYINSERTALL("arrayInsertAll"),
+    ARRAYPREPENDALL("arrayPrependAll"),
+    ARRAYAPPENDALL("arrayAppendAll"),
+    ARRAYADDUNIQUE("arrayAddUnique");
+
+
+    private final String schemaName;
+
+    SubDocumentMode(String schemaName) {
+        this.schemaName = schemaName;
+    }
+
+    public String schemaName() {
+        return schemaName;
+    }
+}

--- a/src/main/java/com/couchbase/connect/kafka/sink/SubDocumentMode.java
+++ b/src/main/java/com/couchbase/connect/kafka/sink/SubDocumentMode.java
@@ -2,7 +2,6 @@ package com.couchbase.connect.kafka.sink;
 
 public enum SubDocumentMode {
     UPSERT("upsert"),
-    MERGE("merge"),
     ARRAYINSERT("arrayInsert"),
     ARRAYPREPEND("arrayPrepend"),
     ARRAYAPPEND("arrayAppend"),

--- a/src/main/java/com/couchbase/connect/kafka/sink/SubDocumentMode.java
+++ b/src/main/java/com/couchbase/connect/kafka/sink/SubDocumentMode.java
@@ -1,23 +1,12 @@
 package com.couchbase.connect.kafka.sink;
 
 public enum SubDocumentMode {
-    UPSERT("upsert"),
-    ARRAYINSERT("arrayInsert"),
-    ARRAYPREPEND("arrayPrepend"),
-    ARRAYAPPEND("arrayAppend"),
-    ARRAYINSERTALL("arrayInsertAll"),
-    ARRAYPREPENDALL("arrayPrependAll"),
-    ARRAYAPPENDALL("arrayAppendAll"),
-    ARRAYADDUNIQUE("arrayAddUnique");
-
-
-    private final String schemaName;
-
-    SubDocumentMode(String schemaName) {
-        this.schemaName = schemaName;
-    }
-
-    public String schemaName() {
-        return schemaName;
-    }
+    UPSERT,
+    ARRAY_INSERT,
+    ARRAY_PREPEND,
+    ARRAY_APPEND,
+    ARRAY_INSERT_ALL,
+    ARRAY_PREPEND_ALL,
+    ARRAY_APPEND_ALL,
+    ARRAY_ADD_UNIQUE;
 }

--- a/src/main/java/com/couchbase/connect/kafka/sink/SubDocumentWriter.java
+++ b/src/main/java/com/couchbase/connect/kafka/sink/SubDocumentWriter.java
@@ -61,35 +61,35 @@ public class SubDocumentWriter {
                     mutation = mutation.upsert(path, node, options);
                     break;
                 }
-                case ARRAYINSERT: {
+                case ARRAY_INSERT: {
                     mutation = mutation.arrayInsert(path, node, options);
                     break;
                 }
-                case ARRAYAPPEND: {
+                case ARRAY_APPEND: {
                     mutation = mutation.arrayAppend(path, node, options);
 
                     break;
                 }
-                case ARRAYPREPEND: {
+                case ARRAY_PREPEND: {
                     mutation = mutation.arrayPrepend(path, node, options);
 
                     break;
                 }
-                case ARRAYINSERTALL: {
+                case ARRAY_INSERT_ALL: {
                     mutation = mutation.arrayInsertAll(path, node, options);
 
                     break;
                 }
-                case ARRAYAPPENDALL: {
+                case ARRAY_APPEND_ALL: {
                     mutation = mutation.arrayAppendAll(path, node, options);
 
                     break;
                 }
-                case ARRAYPREPENDALL: {
+                case ARRAY_PREPEND_ALL: {
                     mutation = mutation.arrayPrependAll(path, node, options);
                     break;
                 }
-                case ARRAYADDUNIQUE: {
+                case ARRAY_ADD_UNIQUE: {
                     mutation = mutation.arrayAddUnique(path, node, options);
                     break;
                 }
@@ -101,7 +101,7 @@ public class SubDocumentWriter {
                 .doOnError(new Action1<Throwable>() {
                     @Override
                     public void call(Throwable throwable) {
-                        if(createDocuments && DocumentDoesNotExistException.class.isInstance(throwable)) {
+                        if(createDocuments && throwable instanceof DocumentDoesNotExistException) {
                             bucket.insert(JsonDocument.create(document.id())).toBlocking().single();
                         }
                     }

--- a/src/main/java/com/couchbase/connect/kafka/sink/SubDocumentWriter.java
+++ b/src/main/java/com/couchbase/connect/kafka/sink/SubDocumentWriter.java
@@ -1,42 +1,21 @@
 package com.couchbase.connect.kafka.sink;
 
-import com.couchbase.client.core.message.kv.subdoc.multi.Mutation;
-import com.couchbase.client.deps.com.fasterxml.jackson.core.JsonFactory;
-import com.couchbase.client.deps.com.fasterxml.jackson.core.JsonParser;
-import com.couchbase.client.deps.com.fasterxml.jackson.core.TreeNode;
-import com.couchbase.client.deps.com.fasterxml.jackson.databind.ObjectMapper;
-import com.couchbase.client.deps.io.netty.buffer.ByteBuf;
 import com.couchbase.client.java.AsyncBucket;
-import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.PersistTo;
 import com.couchbase.client.java.ReplicateTo;
-import com.couchbase.client.java.document.Document;
 import com.couchbase.client.java.document.JsonDocument;
 import com.couchbase.client.java.document.json.JsonObject;
 import com.couchbase.client.java.error.DocumentDoesNotExistException;
 import com.couchbase.client.java.subdoc.AsyncMutateInBuilder;
-import com.couchbase.client.java.subdoc.DocumentFragment;
 import com.couchbase.client.java.subdoc.SubdocOptionsBuilder;
-import com.couchbase.connect.kafka.CouchbaseSinkConnectorConfig;
-import com.couchbase.connect.kafka.CouchbaseSinkTaskConfig;
 import com.couchbase.connect.kafka.util.JsonBinaryDocument;
-import org.apache.kafka.common.config.ConfigException;
-import org.apache.kafka.connect.errors.ConnectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Completable;
 
-import java.io.IOException;
-import java.util.Iterator;
-import java.util.Map;
-
-import com.couchbase.connect.kafka.sink.SubDocumentMode;
-import rx.Observable;
 import rx.functions.Action1;
-import rx.functions.Func1;
 
 import static com.couchbase.client.deps.io.netty.util.CharsetUtil.UTF_8;
-import static com.couchbase.connect.kafka.CouchbaseSinkConnectorConfig.SUBDOCUMENT_MODE_CONFIG;
 
 public class SubDocumentWriter {
 

--- a/src/main/java/com/couchbase/connect/kafka/sink/SubDocumentWriter.java
+++ b/src/main/java/com/couchbase/connect/kafka/sink/SubDocumentWriter.java
@@ -1,0 +1,133 @@
+package com.couchbase.connect.kafka.sink;
+
+import com.couchbase.client.core.message.kv.subdoc.multi.Mutation;
+import com.couchbase.client.deps.com.fasterxml.jackson.core.JsonFactory;
+import com.couchbase.client.deps.com.fasterxml.jackson.core.JsonParser;
+import com.couchbase.client.deps.com.fasterxml.jackson.core.TreeNode;
+import com.couchbase.client.deps.com.fasterxml.jackson.databind.ObjectMapper;
+import com.couchbase.client.deps.io.netty.buffer.ByteBuf;
+import com.couchbase.client.java.AsyncBucket;
+import com.couchbase.client.java.Bucket;
+import com.couchbase.client.java.PersistTo;
+import com.couchbase.client.java.ReplicateTo;
+import com.couchbase.client.java.document.Document;
+import com.couchbase.client.java.document.JsonDocument;
+import com.couchbase.client.java.document.json.JsonObject;
+import com.couchbase.client.java.error.DocumentDoesNotExistException;
+import com.couchbase.client.java.subdoc.AsyncMutateInBuilder;
+import com.couchbase.client.java.subdoc.DocumentFragment;
+import com.couchbase.client.java.subdoc.SubdocOptionsBuilder;
+import com.couchbase.connect.kafka.CouchbaseSinkConnectorConfig;
+import com.couchbase.connect.kafka.CouchbaseSinkTaskConfig;
+import com.couchbase.connect.kafka.util.JsonBinaryDocument;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import rx.Completable;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
+
+import com.couchbase.connect.kafka.sink.SubDocumentMode;
+import rx.Observable;
+import rx.functions.Action1;
+import rx.functions.Func1;
+
+import static com.couchbase.client.deps.io.netty.util.CharsetUtil.UTF_8;
+import static com.couchbase.connect.kafka.CouchbaseSinkConnectorConfig.SUBDOCUMENT_MODE_CONFIG;
+
+public class SubDocumentWriter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SubDocumentWriter.class);
+
+    private SubDocumentMode mode;
+
+    private String path;
+
+    private boolean createPaths;
+
+    private boolean createDocuments;
+
+    public SubDocumentWriter(SubDocumentMode mode, String path, boolean createPaths, boolean createDocuments) {
+
+        this.mode = mode;
+        this.path = path;
+        this.createPaths = createPaths;
+        this.createDocuments = createDocuments;
+    }
+
+    public Completable write(final AsyncBucket bucket, final JsonBinaryDocument document, PersistTo persistTo, ReplicateTo replicateTo) {
+        if (document == null || (document.content() == null && (document.id() == null || document.id().isEmpty()))) {
+
+            LOGGER.warn("document or document content is null");
+            // skip it
+            return Completable.complete();
+        }
+
+        JsonObject node = JsonObject.fromJson(document.content().toString(UTF_8));
+
+        SubdocOptionsBuilder options = new SubdocOptionsBuilder().createPath(createPaths);
+
+        AsyncMutateInBuilder mutation = bucket
+                .mutateIn(document.id());
+
+        if (document.content() == null && !document.id().isEmpty()) {
+            mutation = mutation.remove(path, options);
+        }
+        else {
+            switch (mode) {
+                case UPSERT: {
+                    mutation = mutation.upsert(path, node, options);
+                    break;
+                }
+                case ARRAYINSERT: {
+                    mutation = mutation.arrayInsert(path, node, options);
+                    break;
+                }
+                case ARRAYAPPEND: {
+                    mutation = mutation.arrayAppend(path, node, options);
+
+                    break;
+                }
+                case ARRAYPREPEND: {
+                    mutation = mutation.arrayPrepend(path, node, options);
+
+                    break;
+                }
+                case ARRAYINSERTALL: {
+                    mutation = mutation.arrayInsertAll(path, node, options);
+
+                    break;
+                }
+                case ARRAYAPPENDALL: {
+                    mutation = mutation.arrayAppendAll(path, node, options);
+
+                    break;
+                }
+                case ARRAYPREPENDALL: {
+                    mutation = mutation.arrayPrependAll(path, node, options);
+                    break;
+                }
+                case ARRAYADDUNIQUE: {
+                    mutation = mutation.arrayAddUnique(path, node, options);
+                    break;
+                }
+            }
+        }
+
+        return mutation
+                .execute(persistTo, replicateTo)
+                .doOnError(new Action1<Throwable>() {
+                    @Override
+                    public void call(Throwable throwable) {
+                        if(createDocuments && DocumentDoesNotExistException.class.isInstance(throwable)) {
+                            bucket.insert(JsonDocument.create(document.id())).toBlocking().single();
+                        }
+                    }
+                })
+                .toCompletable();
+    }
+}
+

--- a/src/test/java/com/couchbase/connect/kafka/sink/N1qlWriterTest.java
+++ b/src/test/java/com/couchbase/connect/kafka/sink/N1qlWriterTest.java
@@ -97,10 +97,10 @@ public class N1qlWriterTest {
         verify(bucket).query(argument.capture());
 
         ParameterizedN1qlQuery query = (ParameterizedN1qlQuery) argument.getValue();
-        assertEquals("UPDATE `default` USE KEYS \"id\" SET boolean = $boolean, string = $string, double = $double, int = $int, long = $long RETURNING meta().id;",
+        assertEquals("UPDATE `default` USE KEYS $__id__ SET boolean = $boolean, string = $string, double = $double, int = $int, long = $long RETURNING meta().id;",
                 query.statement().toString());
 
-        assertEquals(object.toString(), query.statementParameters().toString());
+        assertEquals(object.put("__id__","id").toString(), query.statementParameters().toString());
     }
 
     @Test
@@ -114,8 +114,8 @@ public class N1qlWriterTest {
         ParameterizedN1qlQuery query = (ParameterizedN1qlQuery) argument.getValue();
 
         assertNotNull(query);
-        assertEquals("UPDATE `default` USE KEYS \"id\" SET test = $test RETURNING meta().id;", query.statement().toString());
-        assertEquals(object, query.statementParameters());
+        assertEquals("UPDATE `default` USE KEYS $__id__ SET test = $test RETURNING meta().id;", query.statement().toString());
+        assertEquals(object.put("__id__","id"), query.statementParameters());
     }
 
     @Test

--- a/src/test/java/com/couchbase/connect/kafka/sink/SubDocumentWriterTest.java
+++ b/src/test/java/com/couchbase/connect/kafka/sink/SubDocumentWriterTest.java
@@ -121,7 +121,7 @@ public class SubDocumentWriterTest {
         Mockito.when(mutateInBuilder.arrayInsert(Mockito.any(String.class), Mockito.any(JsonObject.class), Mockito.any(SubdocOptionsBuilder.class)))
                 .thenReturn(mutateInBuilder);
 
-        Completable r = write(object, SubDocumentMode.ARRAYINSERT);
+        Completable r = write(object, SubDocumentMode.ARRAY_INSERT);
 
         verify(bucket).mutateIn(mutateInArg.capture());
         verify(mutateInBuilder).arrayInsert(Mockito.eq(path), Mockito.eq(object), Mockito.any(SubdocOptionsBuilder.class));
@@ -136,7 +136,7 @@ public class SubDocumentWriterTest {
         Mockito.when(mutateInBuilder.arrayAppend(Mockito.any(String.class), Mockito.any(JsonObject.class), Mockito.any(SubdocOptionsBuilder.class)))
                 .thenReturn(mutateInBuilder);
 
-        Completable r = write(object, SubDocumentMode.ARRAYAPPEND);
+        Completable r = write(object, SubDocumentMode.ARRAY_APPEND);
 
         verify(bucket).mutateIn(mutateInArg.capture());
         verify(mutateInBuilder).arrayAppend(Mockito.eq(path), Mockito.eq(object), Mockito.any(SubdocOptionsBuilder.class));
@@ -151,7 +151,7 @@ public class SubDocumentWriterTest {
         Mockito.when(mutateInBuilder.arrayPrepend(Mockito.any(String.class), Mockito.any(JsonObject.class), Mockito.any(SubdocOptionsBuilder.class)))
                 .thenReturn(mutateInBuilder);
 
-        Completable r = write(object, SubDocumentMode.ARRAYPREPEND);
+        Completable r = write(object, SubDocumentMode.ARRAY_PREPEND);
 
         verify(bucket).mutateIn(mutateInArg.capture());
         verify(mutateInBuilder).arrayPrepend(Mockito.eq(path), Mockito.eq(object), Mockito.any(SubdocOptionsBuilder.class));
@@ -166,7 +166,7 @@ public class SubDocumentWriterTest {
         Mockito.when(mutateInBuilder.arrayInsertAll(Mockito.any(String.class), Mockito.any(JsonObject.class), Mockito.any(SubdocOptionsBuilder.class)))
                 .thenReturn(mutateInBuilder);
 
-        Completable r = write(object, SubDocumentMode.ARRAYINSERTALL);
+        Completable r = write(object, SubDocumentMode.ARRAY_INSERT_ALL);
 
         verify(bucket).mutateIn(mutateInArg.capture());
         verify(mutateInBuilder).arrayInsertAll(Mockito.eq(path), Mockito.eq(object), Mockito.any(SubdocOptionsBuilder.class));
@@ -181,7 +181,7 @@ public class SubDocumentWriterTest {
         Mockito.when(mutateInBuilder.arrayAppendAll(Mockito.any(String.class), Mockito.any(JsonObject.class), Mockito.any(SubdocOptionsBuilder.class)))
                 .thenReturn(mutateInBuilder);
 
-        Completable r = write(object, SubDocumentMode.ARRAYAPPENDALL);
+        Completable r = write(object, SubDocumentMode.ARRAY_APPEND_ALL);
 
         verify(bucket).mutateIn(mutateInArg.capture());
         verify(mutateInBuilder).arrayAppendAll(Mockito.eq(path), Mockito.eq(object), Mockito.any(SubdocOptionsBuilder.class));
@@ -196,7 +196,7 @@ public class SubDocumentWriterTest {
         Mockito.when(mutateInBuilder.arrayPrependAll(Mockito.any(String.class), Mockito.any(JsonObject.class), Mockito.any(SubdocOptionsBuilder.class)))
                 .thenReturn(mutateInBuilder);
 
-        Completable r = write(object, SubDocumentMode.ARRAYPREPENDALL);
+        Completable r = write(object, SubDocumentMode.ARRAY_PREPEND_ALL);
 
         verify(bucket).mutateIn(mutateInArg.capture());
         verify(mutateInBuilder).arrayPrependAll(Mockito.eq(path), Mockito.eq(object), Mockito.any(SubdocOptionsBuilder.class));
@@ -211,7 +211,7 @@ public class SubDocumentWriterTest {
         Mockito.when(mutateInBuilder.arrayAddUnique(Mockito.any(String.class), Mockito.any(JsonObject.class), Mockito.any(SubdocOptionsBuilder.class)))
                 .thenReturn(mutateInBuilder);
 
-        Completable r = write(object, SubDocumentMode.ARRAYADDUNIQUE);
+        Completable r = write(object, SubDocumentMode.ARRAY_ADD_UNIQUE);
 
         verify(bucket).mutateIn(mutateInArg.capture());
         verify(mutateInBuilder).arrayAddUnique(Mockito.eq(path), Mockito.eq(object), Mockito.any(SubdocOptionsBuilder.class));
@@ -229,7 +229,7 @@ public class SubDocumentWriterTest {
         Mockito.when(mutateInBuilder.arrayAddUnique(Mockito.any(String.class), Mockito.any(JsonObject.class), Mockito.any(SubdocOptionsBuilder.class)))
                 .thenReturn(mutateInBuilder);
 
-        Completable r = write(object, SubDocumentMode.ARRAYADDUNIQUE, error);
+        Completable r = write(object, SubDocumentMode.ARRAY_ADD_UNIQUE, error);
 
         verify(bucket).mutateIn(mutateInArg.capture());
         verify(mutateInBuilder).arrayAddUnique(Mockito.eq(path), Mockito.eq(object), Mockito.any(SubdocOptionsBuilder.class));
@@ -248,7 +248,7 @@ public class SubDocumentWriterTest {
         Mockito.when(mutateInBuilder.arrayAddUnique(Mockito.any(String.class), Mockito.any(JsonObject.class), Mockito.any(SubdocOptionsBuilder.class)))
                 .thenReturn(mutateInBuilder);
 
-        Completable r = write(object, SubDocumentMode.ARRAYADDUNIQUE, error);
+        Completable r = write(object, SubDocumentMode.ARRAY_ADD_UNIQUE, error);
 
         verify(bucket).mutateIn(mutateInArg.capture());
         verify(mutateInBuilder).arrayAddUnique(Mockito.eq(path), Mockito.eq(object), Mockito.any(SubdocOptionsBuilder.class));

--- a/src/test/java/com/couchbase/connect/kafka/sink/SubDocumentWriterTest.java
+++ b/src/test/java/com/couchbase/connect/kafka/sink/SubDocumentWriterTest.java
@@ -1,0 +1,261 @@
+package com.couchbase.connect.kafka.sink;
+
+import com.couchbase.client.core.message.kv.subdoc.multi.Mutation;
+import com.couchbase.client.java.AsyncBucket;
+import com.couchbase.client.java.PersistTo;
+import com.couchbase.client.java.ReplicateTo;
+import com.couchbase.client.java.document.JsonDocument;
+import com.couchbase.client.java.document.json.JsonObject;
+import com.couchbase.client.java.error.DocumentDoesNotExistException;
+import com.couchbase.client.java.error.subdoc.CannotInsertValueException;
+import com.couchbase.client.java.subdoc.AsyncMutateInBuilder;
+import com.couchbase.client.java.subdoc.DocumentFragment;
+import com.couchbase.client.java.subdoc.SubdocOptionsBuilder;
+import com.couchbase.connect.kafka.util.JsonBinaryDocument;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import rx.Completable;
+import rx.Observable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.couchbase.client.deps.io.netty.util.CharsetUtil.UTF_8;
+
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SubDocumentWriterTest {
+
+    private SubDocumentWriter writer;
+
+    private final String path = "leaf";
+
+    @Mock
+    private AsyncBucket bucket;
+
+    @Mock
+    private AsyncMutateInBuilder mutateInBuilder;
+
+    @Captor
+    private ArgumentCaptor<String> mutateInArg;
+
+    Observable<DocumentFragment<Mutation>> emptyResult = Observable.empty();
+
+    @Before
+    public void before(){
+        Observable<DocumentFragment<Mutation>> result = Observable.empty();
+        List<JsonDocument> documents = new ArrayList();
+        documents.add(JsonDocument.create("id"));
+
+        Observable<JsonDocument> insert = Observable.from(documents);
+
+        Mockito.when(bucket.name()).thenReturn("default");
+        Mockito.when(bucket.mutateIn(Mockito.any(String.class))).thenReturn(mutateInBuilder);
+        Mockito.when(bucket.insert(Mockito.any(JsonDocument.class))).thenReturn(insert);
+    }
+
+    private Completable write(JsonObject object, SubDocumentMode mode){
+        return write(object,mode, emptyResult);
+    }
+
+    private Completable write(JsonObject object, SubDocumentMode mode, Observable<DocumentFragment<Mutation>> result){
+        Mockito.when(mutateInBuilder.execute(Mockito.any(PersistTo.class),Mockito.any(ReplicateTo.class))).thenReturn(result);
+
+        writer = new SubDocumentWriter(mode,path,true,true);
+
+        JsonBinaryDocument document = null;
+        if(object != null){
+            document = JsonBinaryDocument.create("id", object.toString().getBytes(UTF_8));
+        }
+
+        return  writer.write(bucket, document, PersistTo.NONE, ReplicateTo.NONE);
+    }
+
+    @Test
+    public void doesNotGenerateStatementOnNull()  {
+        write(null, SubDocumentMode.UPSERT);
+
+        verify(bucket, never()).mutateIn(mutateInArg.capture());
+    }
+
+    @Test
+    public void upsertsPathWithEmptyJsonObject() {
+
+        Mockito.when(mutateInBuilder.upsert(Mockito.any(String.class), Mockito.any(JsonObject.class), Mockito.any(SubdocOptionsBuilder.class)))
+                .thenReturn(mutateInBuilder);
+
+        Completable r = write(JsonObject.empty(), SubDocumentMode.UPSERT);
+        verify(bucket).mutateIn(mutateInArg.capture());
+
+        r.await();
+    }
+
+    @Test
+    public void upsertsPathWithJsonObject() {
+        JsonObject object = JsonObject.create();
+
+        Mockito.when(mutateInBuilder.upsert(Mockito.any(String.class), Mockito.any(JsonObject.class), Mockito.any(SubdocOptionsBuilder.class)))
+                .thenReturn(mutateInBuilder);
+
+        Completable r = write(object, SubDocumentMode.UPSERT);
+
+        verify(bucket).mutateIn(mutateInArg.capture());
+        verify(mutateInBuilder).upsert(Mockito.eq(path), Mockito.eq(object), Mockito.any(SubdocOptionsBuilder.class));
+
+        r.await();
+    }
+
+    @Test
+    public void insertsToArray() {
+        JsonObject object = JsonObject.create();
+
+        Mockito.when(mutateInBuilder.arrayInsert(Mockito.any(String.class), Mockito.any(JsonObject.class), Mockito.any(SubdocOptionsBuilder.class)))
+                .thenReturn(mutateInBuilder);
+
+        Completable r = write(object, SubDocumentMode.ARRAYINSERT);
+
+        verify(bucket).mutateIn(mutateInArg.capture());
+        verify(mutateInBuilder).arrayInsert(Mockito.eq(path), Mockito.eq(object), Mockito.any(SubdocOptionsBuilder.class));
+
+        r.await();
+    }
+
+    @Test
+    public void appendsToArray() {
+        JsonObject object = JsonObject.create();
+
+        Mockito.when(mutateInBuilder.arrayAppend(Mockito.any(String.class), Mockito.any(JsonObject.class), Mockito.any(SubdocOptionsBuilder.class)))
+                .thenReturn(mutateInBuilder);
+
+        Completable r = write(object, SubDocumentMode.ARRAYAPPEND);
+
+        verify(bucket).mutateIn(mutateInArg.capture());
+        verify(mutateInBuilder).arrayAppend(Mockito.eq(path), Mockito.eq(object), Mockito.any(SubdocOptionsBuilder.class));
+
+        r.await();
+    }
+
+    @Test
+    public void prependsToArray() {
+        JsonObject object = JsonObject.create();
+
+        Mockito.when(mutateInBuilder.arrayPrepend(Mockito.any(String.class), Mockito.any(JsonObject.class), Mockito.any(SubdocOptionsBuilder.class)))
+                .thenReturn(mutateInBuilder);
+
+        Completable r = write(object, SubDocumentMode.ARRAYPREPEND);
+
+        verify(bucket).mutateIn(mutateInArg.capture());
+        verify(mutateInBuilder).arrayPrepend(Mockito.eq(path), Mockito.eq(object), Mockito.any(SubdocOptionsBuilder.class));
+
+        r.await();
+    }
+
+    @Test
+    public void insertsAllToArray() {
+        JsonObject object = JsonObject.create();
+
+        Mockito.when(mutateInBuilder.arrayInsertAll(Mockito.any(String.class), Mockito.any(JsonObject.class), Mockito.any(SubdocOptionsBuilder.class)))
+                .thenReturn(mutateInBuilder);
+
+        Completable r = write(object, SubDocumentMode.ARRAYINSERTALL);
+
+        verify(bucket).mutateIn(mutateInArg.capture());
+        verify(mutateInBuilder).arrayInsertAll(Mockito.eq(path), Mockito.eq(object), Mockito.any(SubdocOptionsBuilder.class));
+
+        r.await();
+    }
+
+    @Test
+    public void appendsAllToArray() {
+        JsonObject object = JsonObject.create();
+
+        Mockito.when(mutateInBuilder.arrayAppendAll(Mockito.any(String.class), Mockito.any(JsonObject.class), Mockito.any(SubdocOptionsBuilder.class)))
+                .thenReturn(mutateInBuilder);
+
+        Completable r = write(object, SubDocumentMode.ARRAYAPPENDALL);
+
+        verify(bucket).mutateIn(mutateInArg.capture());
+        verify(mutateInBuilder).arrayAppendAll(Mockito.eq(path), Mockito.eq(object), Mockito.any(SubdocOptionsBuilder.class));
+
+        r.await();
+    }
+
+    @Test
+    public void prependsAllToArray() {
+        JsonObject object = JsonObject.create();
+
+        Mockito.when(mutateInBuilder.arrayPrependAll(Mockito.any(String.class), Mockito.any(JsonObject.class), Mockito.any(SubdocOptionsBuilder.class)))
+                .thenReturn(mutateInBuilder);
+
+        Completable r = write(object, SubDocumentMode.ARRAYPREPENDALL);
+
+        verify(bucket).mutateIn(mutateInArg.capture());
+        verify(mutateInBuilder).arrayPrependAll(Mockito.eq(path), Mockito.eq(object), Mockito.any(SubdocOptionsBuilder.class));
+
+        r.await();
+    }
+
+    @Test
+    public void addsToArrayUnique() {
+        JsonObject object = JsonObject.create();
+
+        Mockito.when(mutateInBuilder.arrayAddUnique(Mockito.any(String.class), Mockito.any(JsonObject.class), Mockito.any(SubdocOptionsBuilder.class)))
+                .thenReturn(mutateInBuilder);
+
+        Completable r = write(object, SubDocumentMode.ARRAYADDUNIQUE);
+
+        verify(bucket).mutateIn(mutateInArg.capture());
+        verify(mutateInBuilder).arrayAddUnique(Mockito.eq(path), Mockito.eq(object), Mockito.any(SubdocOptionsBuilder.class));
+
+        r.await();
+
+    }
+
+    @Test(expected = DocumentDoesNotExistException.class)
+    public void createsDocumentOnDocumentDoesNotExistException() {
+        Observable<DocumentFragment<Mutation>> error = Observable.error(new DocumentDoesNotExistException());
+
+        JsonObject object = JsonObject.create();
+
+        Mockito.when(mutateInBuilder.arrayAddUnique(Mockito.any(String.class), Mockito.any(JsonObject.class), Mockito.any(SubdocOptionsBuilder.class)))
+                .thenReturn(mutateInBuilder);
+
+        Completable r = write(object, SubDocumentMode.ARRAYADDUNIQUE, error);
+
+        verify(bucket).mutateIn(mutateInArg.capture());
+        verify(mutateInBuilder).arrayAddUnique(Mockito.eq(path), Mockito.eq(object), Mockito.any(SubdocOptionsBuilder.class));
+
+        r.await();
+
+        verify(bucket).insert(Mockito.any(JsonDocument.class));
+    }
+
+    @Test(expected = CannotInsertValueException.class)
+    public void ignoresOtherThrowables() {
+        Observable<DocumentFragment<Mutation>> error = Observable.error(new CannotInsertValueException(path));
+
+        JsonObject object = JsonObject.create();
+
+        Mockito.when(mutateInBuilder.arrayAddUnique(Mockito.any(String.class), Mockito.any(JsonObject.class), Mockito.any(SubdocOptionsBuilder.class)))
+                .thenReturn(mutateInBuilder);
+
+        Completable r = write(object, SubDocumentMode.ARRAYADDUNIQUE, error);
+
+        verify(bucket).mutateIn(mutateInArg.capture());
+        verify(mutateInBuilder).arrayAddUnique(Mockito.eq(path), Mockito.eq(object), Mockito.any(SubdocOptionsBuilder.class));
+
+        r.await();
+
+        verify(bucket, never()).insert(Mockito.any(JsonDocument.class));
+    }
+
+}


### PR DESCRIPTION
I have added code to allow two new types of operations using the sink connector. You can set the mode using the configuration 

`couchbase.document.mode=DOCUMENT|SUBDOCUMENT|N1QL`

this setting defaults to DOCUMENT and leaves the original behavior as is. 

1. SUBDOCUMENT
this setting will make the sink work on subdocuments using the official subdocument API. you can specify the following settings to control the behavior:
`
couchbase.subdocument.mode=UPSERT(default)|ARRAYINSERT|ARRAYPREPEND|ARRAYAPPEND|ARRAYINSERTALL|ARRAYPREPENDALL|ARRAYAPPENDALL|ARRAYADDUNIQUE
couchbase.subdocument.path='path in document'
couchbase.subdocument.createpath=true(default)|false
couchbase.subdocument.createdocument=true(default)|false
`

2. N1QL
this setting will make the sink work with N1QL, generating UPDATE or UPSERT statements ON KEYS . you can specifiy the following settings to control the behavior:
`
couchbase.n1ql.mode=UPSERT(default)|UPDATE
couchbase.subdocument.createdocument=true(default)|false
` 
in UPDATE mode, data is added to existing documents (more like a merge) whereas UPSERT replaces the content with the data in the sink record. if the createdocument option is set to true and the update yields 0 changed rows, the message is retried with an upsert statement.

i think there is room for improvement in the retrying of the new commands but i might need some help in doing that correctly with RxJava.