### PR TITLE
enable path to be sourced from the body similar to the id.

### DIFF
--- a/src/main/java/com/couchbase/connect/kafka/CouchbaseSinkTask.java
+++ b/src/main/java/com/couchbase/connect/kafka/CouchbaseSinkTask.java
@@ -35,10 +35,7 @@ import com.couchbase.connect.kafka.sink.N1qlMode;
 import com.couchbase.connect.kafka.sink.N1qlWriter;
 import com.couchbase.connect.kafka.sink.SubDocumentMode;
 import com.couchbase.connect.kafka.sink.SubDocumentWriter;
-import com.couchbase.connect.kafka.util.DocumentIdExtractor;
-import com.couchbase.connect.kafka.util.JsonBinaryDocument;
-import com.couchbase.connect.kafka.util.JsonBinaryTranscoder;
-import com.couchbase.connect.kafka.util.Version;
+import com.couchbase.connect.kafka.util.*;
 import com.couchbase.connect.kafka.util.config.DurationParser;
 import com.couchbase.connect.kafka.util.config.Password;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
@@ -165,7 +162,7 @@ public class CouchbaseSinkTask extends SinkTask {
                 createPaths = config.getBoolean(CouchbaseSinkConnectorConfig.SUBDOCUMENT_CREATEPATH_CONFIG);
                 createDocuments = config.getBoolean(CouchbaseSinkConnectorConfig.SUBDOCUMENT_CREATEDOCUMENT_CONFIG);
 
-                subDocumentWriter = new SubDocumentWriter(subDocumentMode, path, createPaths, createDocuments);
+                subDocumentWriter = new SubDocumentWriter(subDocumentMode, path, path.startsWith("/"), createPaths, createDocuments);
                 break;
             }
             case N1QL: {
@@ -275,7 +272,7 @@ public class CouchbaseSinkTask extends SinkTask {
                 return documentIdExtractor.extractDocumentId(valueAsJsonBytes, getAbsoluteExpirySeconds());
             }
 
-        } catch (DocumentIdExtractor.DocumentIdNotFoundException e) {
+        } catch (DocumentPathExtractor.DocumentPathNotFoundException e) {
             defaultId = documentIdFromKafkaMetadata(record);
             LOGGER.warn(e.getMessage() + "; using fallback ID '{}'", defaultId);
 

--- a/src/main/java/com/couchbase/connect/kafka/sink/SubDocumentWriter.java
+++ b/src/main/java/com/couchbase/connect/kafka/sink/SubDocumentWriter.java
@@ -1,23 +1,55 @@
 package com.couchbase.connect.kafka.sink;
 
+import com.couchbase.client.deps.io.netty.buffer.ByteBuf;
 import com.couchbase.client.java.AsyncBucket;
 import com.couchbase.client.java.PersistTo;
 import com.couchbase.client.java.ReplicateTo;
-import com.couchbase.client.java.document.JsonDocument;
 import com.couchbase.client.java.document.json.JsonObject;
-import com.couchbase.client.java.error.DocumentDoesNotExistException;
 import com.couchbase.client.java.subdoc.AsyncMutateInBuilder;
 import com.couchbase.client.java.subdoc.SubdocOptionsBuilder;
+import com.couchbase.connect.kafka.util.DocumentPathExtractor;
 import com.couchbase.connect.kafka.util.JsonBinaryDocument;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Completable;
 
-import rx.functions.Action1;
+import java.io.IOException;
 
 import static com.couchbase.client.deps.io.netty.util.CharsetUtil.UTF_8;
 
 public class SubDocumentWriter {
+
+    private class SubdocOperation
+    {
+        private String id;
+        private String path;
+        private JsonObject data;
+
+        public String getId(){
+            return id;
+        }
+
+        public void setId(String id){
+            this.id = id;
+        }
+
+        public String getPath(){
+            return path;
+        }
+
+        public void setPath(String path){
+            this.path = path;
+        }
+
+        public JsonObject getData() {
+            return data;
+        }
+
+        public void setData(ByteBuf data){
+            this.data = JsonObject.fromJson(data.toString(UTF_8));
+
+        }
+    }
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SubDocumentWriter.class);
 
@@ -27,12 +59,15 @@ public class SubDocumentWriter {
 
     private boolean createPaths;
 
+    private boolean extractPath;
+
     private boolean createDocuments;
 
-    public SubDocumentWriter(SubDocumentMode mode, String path, boolean createPaths, boolean createDocuments) {
+    public SubDocumentWriter(SubDocumentMode mode, String path, boolean extractPath, boolean createPaths, boolean createDocuments) {
 
         this.mode = mode;
         this.path = path;
+        this.extractPath = extractPath;
         this.createPaths = createPaths;
         this.createDocuments = createDocuments;
     }
@@ -45,52 +80,52 @@ public class SubDocumentWriter {
             return Completable.complete();
         }
 
-        JsonObject node = JsonObject.fromJson(document.content().toString(UTF_8));
+        SubdocOperation operation = getOperation(document);
 
         SubdocOptionsBuilder options = new SubdocOptionsBuilder().createPath(createPaths);
 
         AsyncMutateInBuilder mutation = bucket
                 .mutateIn(document.id());
 
-        if (document.content() == null && !document.id().isEmpty()) {
-            mutation = mutation.remove(path, options);
+        if (operation.data == null && !document.id().isEmpty()) {
+            mutation = mutation.remove(operation.path, options);
         }
         else {
             switch (mode) {
                 case UPSERT: {
-                    mutation = mutation.upsert(path, node, options);
+                    mutation = mutation.upsert(operation.getPath(), operation.getData(), options);
                     break;
                 }
                 case ARRAY_INSERT: {
-                    mutation = mutation.arrayInsert(path, node, options);
+                    mutation = mutation.arrayInsert(operation.getPath(), operation.getData(), options);
                     break;
                 }
                 case ARRAY_APPEND: {
-                    mutation = mutation.arrayAppend(path, node, options);
+                    mutation = mutation.arrayAppend(operation.getPath(), operation.getData(), options);
 
                     break;
                 }
                 case ARRAY_PREPEND: {
-                    mutation = mutation.arrayPrepend(path, node, options);
+                    mutation = mutation.arrayPrepend(operation.getPath(), operation.getData(), options);
 
                     break;
                 }
                 case ARRAY_INSERT_ALL: {
-                    mutation = mutation.arrayInsertAll(path, node, options);
+                    mutation = mutation.arrayInsertAll(operation.getPath(), operation.getData(), options);
 
                     break;
                 }
                 case ARRAY_APPEND_ALL: {
-                    mutation = mutation.arrayAppendAll(path, node, options);
+                    mutation = mutation.arrayAppendAll(operation.getPath(), operation.getData(), options);
 
                     break;
                 }
                 case ARRAY_PREPEND_ALL: {
-                    mutation = mutation.arrayPrependAll(path, node, options);
+                    mutation = mutation.arrayPrependAll(operation.getPath(), operation.getData(), options);
                     break;
                 }
                 case ARRAY_ADD_UNIQUE: {
-                    mutation = mutation.arrayAddUnique(path, node, options);
+                    mutation = mutation.arrayAddUnique(operation.getPath(), operation.getData(), options);
                     break;
                 }
             }
@@ -102,5 +137,30 @@ public class SubDocumentWriter {
                 .toCompletable();
 
     }
-}
 
+    private SubdocOperation getOperation(JsonBinaryDocument doc)
+    {
+        SubdocOperation subDocument = new SubdocOperation();
+        subDocument.setId(doc.id());
+
+        ByteBuf data = null;
+        if(extractPath) {
+            DocumentPathExtractor extractor = new DocumentPathExtractor(path,true);
+            try {
+                DocumentPathExtractor.DocumentExtraction extraction = extractor.extractDocumentPath(doc.content().array());
+                subDocument.setPath(extraction.getPathValue());
+                subDocument.setData(extraction.getData());
+            } catch (IOException e) {
+                LOGGER.error(e.getMessage(), e);
+            } catch (DocumentPathExtractor.DocumentPathNotFoundException e) {
+                LOGGER.error(e.getMessage(), e);
+            }
+        }
+        else {
+            subDocument.setPath(path);
+            subDocument.setData(doc.content());
+        }
+
+        return subDocument;
+    }
+}

--- a/src/main/java/com/couchbase/connect/kafka/util/DocumentIdExtractor.java
+++ b/src/main/java/com/couchbase/connect/kafka/util/DocumentIdExtractor.java
@@ -16,20 +16,7 @@
 
 package com.couchbase.connect.kafka.util;
 
-import com.couchbase.client.deps.com.fasterxml.jackson.core.JsonFactory;
-import com.couchbase.client.deps.com.fasterxml.jackson.core.JsonParser;
-import com.couchbase.client.deps.com.fasterxml.jackson.core.JsonPointer;
-import com.couchbase.client.deps.com.fasterxml.jackson.core.filter.FilteringParserDelegate;
-import com.couchbase.client.deps.com.fasterxml.jackson.core.filter.JsonPointerBasedFilter;
-
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Locates a document ID using a JSON pointer, optionally removing the ID from the document.
@@ -38,173 +25,18 @@ import java.util.regex.Pattern;
  */
 public class DocumentIdExtractor {
 
-    public static class DocumentIdNotFoundException extends Exception {
-        public DocumentIdNotFoundException(String message) {
-            super(message);
-        }
-    }
-
-    private static class ByteRange {
-        private final byte[] bytes;
-        private int startOffset;
-        private int pastEndOffset;
-
-        private ByteRange(byte[] bytes, int startOffset, int pastEndOffset) {
-            this.bytes = bytes;
-            this.startOffset = startOffset;
-            this.pastEndOffset = pastEndOffset;
-        }
-
-        private static ByteRange forCurrentToken(byte[] bytes, JsonParser parser) {
-            return new ByteRange(bytes,
-                    (int) parser.getTokenLocation().getByteOffset(),
-                    (int) parser.getCurrentLocation().getByteOffset());
-        }
-
-        @Override
-        public String toString() {
-            return "[" + startOffset + "," + pastEndOffset + ") = |" + new String(bytes, startOffset, pastEndOffset - startOffset) + "|";
-        }
-
-        public void fill(byte[] bytes, byte fillByte) {
-            Arrays.fill(bytes, startOffset, pastEndOffset, fillByte);
-        }
-    }
-
-    private static final JsonFactory factory = new JsonFactory();
-    private final String documentIdFormat;
-    private final Map<String, JsonPointer> placeholderToJsonPointer = new HashMap<String, JsonPointer>();
-
-    private final boolean removeDocumentId;
-
-    private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("\\$\\{(.+?)}");
+    private final DocumentPathExtractor pathExtractor;
 
     public DocumentIdExtractor(String documentIdFormat, boolean removeDocumentId) {
-        if (documentIdFormat.isEmpty()) {
-            throw new IllegalArgumentException("Document ID format must not be empty");
-        }
-
-        Matcher m = PLACEHOLDER_PATTERN.matcher(documentIdFormat);
-        if (!m.find()) {
-            // For backwards compatibility, treat the whole thing as a single JSON pointer
-            documentIdFormat = "${" + documentIdFormat + "}";
-            m = PLACEHOLDER_PATTERN.matcher(documentIdFormat);
-            if (!m.find()) {
-                // Shouldn't happen, since we just added the placeholder delimiters
-                throw new AssertionError("invalid document ID format string");
-            }
-        }
-
-        do {
-            final String placeholder = m.group();
-            final String jsonPointer = m.group(1);
-            placeholderToJsonPointer.put(placeholder, JsonPointer.compile(jsonPointer));
-        } while (m.find());
-
-        this.documentIdFormat = documentIdFormat;
-        this.removeDocumentId = removeDocumentId;
+        pathExtractor = new DocumentPathExtractor(documentIdFormat,removeDocumentId);
     }
 
     /**
      * @param json The document content encoded as UTF-8. If this method returns normally,
      * it may modify the contents of the array to remove the fields used by the document ID.
      */
-    public JsonBinaryDocument extractDocumentId(final byte[] json, int expiry) throws IOException, DocumentIdNotFoundException {
-        final List<ByteRange> rangesToRemove = new ArrayList<ByteRange>(placeholderToJsonPointer.size());
-
-        String documentId = documentIdFormat;
-
-        for (Map.Entry<String, JsonPointer> idComponent : placeholderToJsonPointer.entrySet()) {
-            final String placeholder = idComponent.getKey();
-            final JsonPointer documentIdPointer = idComponent.getValue();
-
-            final JsonParser parser = new FilteringParserDelegate(
-                    factory.createParser(json), new JsonPointerBasedFilter(documentIdPointer), false, false);
-
-            if (parser.nextToken() == null) {
-                throw new DocumentIdNotFoundException("Document has no value matching JSON pointer '" + documentIdPointer + "'");
-            }
-
-            final String component = parser.getValueAsString();
-            if (component == null) {
-                throw new DocumentIdNotFoundException("The value matching JSON pointer '" + documentIdPointer + "' is null or non-scalar.");
-            }
-
-            documentId = documentId.replace(placeholder, component);
-
-            if (removeDocumentId) {
-                rangesToRemove.add(ByteRange.forCurrentToken(json, parser));
-            }
-        }
-
-        // At this point we're sure DocumentIdNotFoundException wasn't thrown, and we can expect
-        // this method to return normally. It is finally safe to modify the document content.
-        for (ByteRange range : rangesToRemove) {
-            swallowFieldName(range);
-            swallowOneComma(range);
-            range.fill(json, (byte) ' ');
-        }
-
-        return JsonBinaryDocument.create(documentId, expiry, json);
-    }
-
-    private static void swallowOneComma(ByteRange range) {
-        swallowWhitespace(range);
-
-        if (range.bytes[range.pastEndOffset] == ',') {
-            range.pastEndOffset++;
-
-        } else if (range.bytes[range.startOffset - 1] == ',') {
-            range.startOffset--;
-        }
-    }
-
-    private static void swallowWhitespace(ByteRange range) {
-        swallowWhitespaceLeft(range);
-        swallowWhitespaceRight(range);
-    }
-
-    private static void swallowWhitespaceLeft(ByteRange range) {
-        while (isJsonWhitespace(range.bytes[range.startOffset - 1])) {
-            range.startOffset--;
-        }
-    }
-
-    private static void swallowWhitespaceRight(ByteRange range) {
-        while (isJsonWhitespace(range.bytes[range.pastEndOffset])) {
-            range.pastEndOffset++;
-        }
-    }
-
-    private static void swallowFieldName(ByteRange range) {
-        swallowWhitespaceLeft(range);
-
-        // If the target was a field, then prevChar will be the colon (:) that separates the field name from value.
-        // If the target was an array element, then prevChar will be the array start token ([) or the comma (,)
-        // separating the target from the previous array element.
-
-        byte prevChar = range.bytes[range.startOffset - 1];
-        if (prevChar == ':') {
-            range.startOffset--; // swallow colon
-            swallowWhitespaceLeft(range);
-            range.startOffset--; // swallow field name closing quote
-
-            // swallow left to include field name opening quote (guaranteed to not be preceded by backslash)
-            do {
-                range.startOffset--;
-            } while (!(range.bytes[range.startOffset] == '"' && range.bytes[range.startOffset - 1] != '\\'));
-        }
-    }
-
-    private static boolean isJsonWhitespace(byte b) {
-        switch (b) {
-            case 0x20: // Space
-            case 0x09: // Horizontal tab
-            case 0x0A: // LF
-            case 0x0D: // CR
-                return true;
-            default:
-                return false;
-        }
+    public JsonBinaryDocument extractDocumentId(final byte[] json, int expiry) throws IOException, DocumentPathExtractor.DocumentPathNotFoundException {
+        DocumentPathExtractor.DocumentExtraction extraction = pathExtractor.extractDocumentPath(json);
+        return JsonBinaryDocument.create(extraction.getPathValue(), expiry, extraction.getData());
     }
 }

--- a/src/main/java/com/couchbase/connect/kafka/util/DocumentPathExtractor.java
+++ b/src/main/java/com/couchbase/connect/kafka/util/DocumentPathExtractor.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2017 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.couchbase.connect.kafka.util;
+
+import com.couchbase.client.deps.com.fasterxml.jackson.core.JsonFactory;
+import com.couchbase.client.deps.com.fasterxml.jackson.core.JsonParser;
+import com.couchbase.client.deps.com.fasterxml.jackson.core.JsonPointer;
+import com.couchbase.client.deps.com.fasterxml.jackson.core.filter.FilteringParserDelegate;
+import com.couchbase.client.deps.com.fasterxml.jackson.core.filter.JsonPointerBasedFilter;
+import com.couchbase.client.deps.io.netty.buffer.ByteBuf;
+import com.couchbase.client.deps.io.netty.buffer.Unpooled;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Locates a document ID using a JSON pointer, optionally removing the ID from the document.
+ * <p>
+ * Immutable.
+ */
+public class DocumentPathExtractor {
+
+    public static class DocumentPathNotFoundException extends Exception {
+        DocumentPathNotFoundException(String message) {
+            super(message);
+        }
+    }
+
+    public class DocumentExtraction {
+        private String pathValue;
+        private ByteBuf data;
+
+        DocumentExtraction(String pathValue, byte[] data) {
+            this.pathValue = pathValue;
+            this.data = Unpooled.wrappedBuffer(data);
+        }
+
+        public String getPathValue(){
+            return pathValue;
+        }
+
+        public ByteBuf getData() {
+            return data;
+        }
+    }
+
+    private static class ByteRange {
+        private final byte[] bytes;
+        private int startOffset;
+        private int pastEndOffset;
+
+        private ByteRange(byte[] bytes, int startOffset, int pastEndOffset) {
+            this.bytes = bytes;
+            this.startOffset = startOffset;
+            this.pastEndOffset = pastEndOffset;
+        }
+
+        private static ByteRange forCurrentToken(byte[] bytes, JsonParser parser) {
+            return new ByteRange(bytes,
+                    (int) parser.getTokenLocation().getByteOffset(),
+                    (int) parser.getCurrentLocation().getByteOffset());
+        }
+
+        @Override
+        public String toString() {
+            return "[" + startOffset + "," + pastEndOffset + ") = |" + new String(bytes, startOffset, pastEndOffset - startOffset) + "|";
+        }
+
+        void fill(byte[] bytes, byte fillByte) {
+            Arrays.fill(bytes, startOffset, pastEndOffset, fillByte);
+        }
+    }
+
+    private static final JsonFactory factory = new JsonFactory();
+    private final String documentPathFormat;
+    private final Map<String, JsonPointer> placeholderToJsonPointer = new HashMap<String, JsonPointer>();
+
+    private final boolean removeDocumentPath;
+
+    private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("\\$\\{(.+?)}");
+
+    public DocumentPathExtractor(String documentPathFormat, boolean removeDocumentPath) {
+        if (documentPathFormat.isEmpty()) {
+            throw new IllegalArgumentException("Document ID format must not be empty");
+        }
+
+        Matcher m = PLACEHOLDER_PATTERN.matcher(documentPathFormat);
+        if (!m.find()) {
+            // For backwards compatibility, treat the whole thing as a single JSON pointer
+            documentPathFormat = "${" + documentPathFormat + "}";
+            m = PLACEHOLDER_PATTERN.matcher(documentPathFormat);
+            if (!m.find()) {
+                // Shouldn't happen, since we just added the placeholder delimiters
+                throw new AssertionError("invalid document ID format string");
+            }
+        }
+
+        do {
+            final String placeholder = m.group();
+            final String jsonPointer = m.group(1);
+            placeholderToJsonPointer.put(placeholder, JsonPointer.compile(jsonPointer));
+        } while (m.find());
+
+        this.documentPathFormat = documentPathFormat;
+        this.removeDocumentPath = removeDocumentPath;
+    }
+
+    /**
+     * @param json The document content encoded as UTF-8. If this method returns normally,
+     * it may modify the contents of the array to remove the fields used by the document ID.
+     */
+    public DocumentExtraction extractDocumentPath(final byte[] json) throws IOException, DocumentPathNotFoundException {
+        final List<ByteRange> rangesToRemove = new ArrayList<ByteRange>(placeholderToJsonPointer.size());
+
+        String documentId = documentPathFormat;
+
+        for (Map.Entry<String, JsonPointer> idComponent : placeholderToJsonPointer.entrySet()) {
+            final String placeholder = idComponent.getKey();
+            final JsonPointer documentIdPointer = idComponent.getValue();
+
+            final JsonParser parser = new FilteringParserDelegate(
+                    factory.createParser(json), new JsonPointerBasedFilter(documentIdPointer), false, false);
+
+            if (parser.nextToken() == null) {
+                throw new DocumentPathNotFoundException("Document has no value matching JSON pointer '" + documentIdPointer + "'");
+            }
+
+            final String component = parser.getValueAsString();
+            if (component == null) {
+                throw new DocumentPathNotFoundException("The value matching JSON pointer '" + documentIdPointer + "' is null or non-scalar.");
+            }
+
+            documentId = documentId.replace(placeholder, component);
+
+            if (removeDocumentPath) {
+                rangesToRemove.add(ByteRange.forCurrentToken(json, parser));
+            }
+        }
+
+        // At this point we're sure DocumentIdNotFoundException wasn't thrown, and we can expect
+        // this method to return normally. It is finally safe to modify the document content.
+        for (ByteRange range : rangesToRemove) {
+            swallowFieldName(range);
+            swallowOneComma(range);
+            range.fill(json, (byte) ' ');
+        }
+
+        return new DocumentExtraction(documentId ,json);
+    }
+
+    private static void swallowOneComma(ByteRange range) {
+        swallowWhitespace(range);
+
+        if (range.bytes[range.pastEndOffset] == ',') {
+            range.pastEndOffset++;
+
+        } else if (range.bytes[range.startOffset - 1] == ',') {
+            range.startOffset--;
+        }
+    }
+
+    private static void swallowWhitespace(ByteRange range) {
+        swallowWhitespaceLeft(range);
+        swallowWhitespaceRight(range);
+    }
+
+    private static void swallowWhitespaceLeft(ByteRange range) {
+        while (isJsonWhitespace(range.bytes[range.startOffset - 1])) {
+            range.startOffset--;
+        }
+    }
+
+    private static void swallowWhitespaceRight(ByteRange range) {
+        while (isJsonWhitespace(range.bytes[range.pastEndOffset])) {
+            range.pastEndOffset++;
+        }
+    }
+
+    private static void swallowFieldName(ByteRange range) {
+        swallowWhitespaceLeft(range);
+
+        // If the target was a field, then prevChar will be the colon (:) that separates the field name from value.
+        // If the target was an array element, then prevChar will be the array start token ([) or the comma (,)
+        // separating the target from the previous array element.
+
+        byte prevChar = range.bytes[range.startOffset - 1];
+        if (prevChar == ':') {
+            range.startOffset--; // swallow colon
+            swallowWhitespaceLeft(range);
+            range.startOffset--; // swallow field name closing quote
+
+            // swallow left to include field name opening quote (guaranteed to not be preceded by backslash)
+            do {
+                range.startOffset--;
+            } while (!(range.bytes[range.startOffset] == '"' && range.bytes[range.startOffset - 1] != '\\'));
+        }
+    }
+
+    private static boolean isJsonWhitespace(byte b) {
+        switch (b) {
+            case 0x20: // Space
+            case 0x09: // Horizontal tab
+            case 0x0A: // LF
+            case 0x0D: // CR
+                return true;
+            default:
+                return false;
+        }
+    }
+}


### PR DESCRIPTION
in order to add multiple messages to the same document in a json tree, we need a way to set the path dynamically. this PR enables to source the path from the contents of the message. 

if the configured path is a json pointer, the value is searched for in the document and removed from the message. if the value isn't a json pointer, the value is treated as a static path inside a document (current behaviour). 


example of dynamic path usage
```
config - couchbase.subdocument.path: /path
message 1 - { 'id":"documentid", "path":"myproperty.value1", "foo":"bar"}
message 2 - { 'id":"documentid", "path":"myproperty.value2", "foo":"baz"}
```
this would result in 

```
{
  "myproperty": 
   {
       "value1":
        {
           "foo":"bar"
        },
        "value2":
        {
           "foo":"baz"
        }
   }
}
```
whereas a static path 

```
config - couchbase.subdocument.path: myproperty.value1
message 1 - { 'id":"documentid",  "foo":"bar"}
message 2 - { 'id":"documentid",  "foo":"baz"}
```

would result in 

```
{
  "myproperty": 
   {
       "value1":
        {
           "foo":"baz"
        }
   }
}
```
