### PR TITLE
added ability to updated documents based on matching fields

### DIFF
--- a/src/main/java/com/couchbase/connect/kafka/CouchbaseSinkConnectorConfig.java
+++ b/src/main/java/com/couchbase/connect/kafka/CouchbaseSinkConnectorConfig.java
@@ -20,6 +20,7 @@ import com.couchbase.client.core.logging.RedactionLevel;
 import com.couchbase.client.java.PersistTo;
 import com.couchbase.client.java.ReplicateTo;
 import com.couchbase.connect.kafka.sink.DocumentMode;
+import com.couchbase.connect.kafka.sink.N1qlClause;
 import com.couchbase.connect.kafka.sink.N1qlMode;
 import com.couchbase.connect.kafka.sink.SubDocumentMode;
 import com.couchbase.connect.kafka.util.config.BooleanParentRecommender;
@@ -102,6 +103,17 @@ public class CouchbaseSinkConnectorConfig extends AbstractConfig {
     static final String N1QL_MODE_DOC = "Setting to indicate the type of update";
     static final String N1QL_MODE_DISPLAY = "N1QL Mode";
     public static final String N1QL_MODE_DEFAULT = N1qlMode.UPSERT.name();
+
+    public static final String N1QL_CLAUSE_CONFIG = "couchbase.n1ql.clause";
+    static final String N1QL_CLAUSE_DOC = "Setting to indicate the type of clause used for the update";
+    static final String N1QL_CLAUSE_DISPLAY = "N1QL Clause";
+    public static final String N1QL_CLAUSE_DEFAULT = N1qlClause.KEYS.name();
+
+    public static final String N1QL_CLAUSE_FIELDS_CONFIG = "couchbase.n1ql.clause.fields";
+    static final String N1QL_CLAUSE_FIELDS_DOC = "Setting to indicate the type of clause used for the update";
+    static final String N1QL_CLAUSE_FIELDS_DISPLAY = "FoN1QL Clause";
+    public static final String N1QL_CLAUSE_FIELDS_DEFAULT = "";
+
 
     public static final String SUBDOCUMENT_CREATEPATH_CONFIG = "couchbase.subdocument.create_path";
     static final String SUBDOCUMENT_CREATEPATH_DOC = "Whether to add the parent paths if they are missing in the document";
@@ -328,12 +340,34 @@ public class CouchbaseSinkConnectorConfig extends AbstractConfig {
                         N1QL_MODE_DISPLAY,
                         new EnumRecommender(N1qlMode.class))
 
+                .define(N1QL_CLAUSE_CONFIG,
+                        ConfigDef.Type.STRING,
+                        N1QL_CLAUSE_DEFAULT,
+                        new EnumValidator(N1qlClause.class),
+                        ConfigDef.Importance.LOW,
+                        N1QL_CLAUSE_DOC,
+                        DATABASE_GROUP, 18,
+                        ConfigDef.Width.LONG,
+                        N1QL_CLAUSE_DISPLAY,
+                        new EnumRecommender(N1qlClause.class))
+
+
+                .define(N1QL_CLAUSE_FIELDS_CONFIG,
+                        ConfigDef.Type.LIST,
+                        N1QL_CLAUSE_FIELDS_DEFAULT,
+                        ConfigDef.Importance.LOW,
+                        N1QL_CLAUSE_FIELDS_DOC,
+                        DATABASE_GROUP, 19,
+                        ConfigDef.Width.LONG,
+                        N1QL_CLAUSE_FIELDS_DISPLAY)
+
+
                 .define(SUBDOCUMENT_CREATEPATH_CONFIG,
                         ConfigDef.Type.BOOLEAN,
                         SUBDOCUMENT_CREATEPATH_DEFAULT,
                         ConfigDef.Importance.LOW,
                         SUBDOCUMENT_CREATEPATH_DOC,
-                        DATABASE_GROUP, 18,
+                        DATABASE_GROUP, 20,
                         ConfigDef.Width.LONG,
                         SUBDOCUMENT_CREATEPATH_DISPLAY)
 
@@ -342,7 +376,7 @@ public class CouchbaseSinkConnectorConfig extends AbstractConfig {
                         SUBDOCUMENT_CREATEDOCUMENT_DEFAULT,
                         ConfigDef.Importance.LOW,
                         SUBDOCUMENT_CREATEDOCUMENT_DOC,
-                        DATABASE_GROUP, 19,
+                        DATABASE_GROUP, 21,
                         ConfigDef.Width.LONG,
                         SUBDOCUMENT_CREATEDOCUMENT_DISPLAY)
 
@@ -351,7 +385,7 @@ public class CouchbaseSinkConnectorConfig extends AbstractConfig {
                         FORCE_IPV4_DEFAULT,
                         ConfigDef.Importance.LOW,
                         FORCE_IPV4_DOC,
-                        CONNECTOR_GROUP, 20,
+                        CONNECTOR_GROUP, 22,
                         ConfigDef.Width.LONG,
                         FORCE_IPV4_DISPLAY)
 
@@ -361,7 +395,7 @@ public class CouchbaseSinkConnectorConfig extends AbstractConfig {
                         new DurationValidator(),
                         ConfigDef.Importance.LOW,
                         EXPIRY_DOC,
-                        CONNECTOR_GROUP, 21,
+                        CONNECTOR_GROUP, 23,
                         ConfigDef.Width.LONG,
                         EXPIRY_DISPLAY)
                 ;

--- a/src/main/java/com/couchbase/connect/kafka/CouchbaseSinkTask.java
+++ b/src/main/java/com/couchbase/connect/kafka/CouchbaseSinkTask.java
@@ -30,11 +30,7 @@ import com.couchbase.client.java.env.DefaultCouchbaseEnvironment;
 import com.couchbase.client.java.error.DocumentDoesNotExistException;
 import com.couchbase.client.java.transcoder.Transcoder;
 import com.couchbase.client.java.util.retry.RetryBuilder;
-import com.couchbase.connect.kafka.sink.DocumentMode;
-import com.couchbase.connect.kafka.sink.N1qlMode;
-import com.couchbase.connect.kafka.sink.N1qlWriter;
-import com.couchbase.connect.kafka.sink.SubDocumentMode;
-import com.couchbase.connect.kafka.sink.SubDocumentWriter;
+import com.couchbase.connect.kafka.sink.*;
 import com.couchbase.connect.kafka.util.DocumentIdExtractor;
 import com.couchbase.connect.kafka.util.JsonBinaryDocument;
 import com.couchbase.connect.kafka.util.JsonBinaryTranscoder;
@@ -63,14 +59,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static com.couchbase.client.deps.io.netty.util.CharsetUtil.UTF_8;
-import static com.couchbase.connect.kafka.CouchbaseSinkConnectorConfig.DOCUMENT_ID_POINTER_CONFIG;
-import static com.couchbase.connect.kafka.CouchbaseSinkConnectorConfig.DOCUMENT_MODE_CONFIG;
-import static com.couchbase.connect.kafka.CouchbaseSinkConnectorConfig.EXPIRY_CONFIG;
-import static com.couchbase.connect.kafka.CouchbaseSinkConnectorConfig.N1QL_MODE_CONFIG;
-import static com.couchbase.connect.kafka.CouchbaseSinkConnectorConfig.PERSIST_TO_CONFIG;
-import static com.couchbase.connect.kafka.CouchbaseSinkConnectorConfig.REMOVE_DOCUMENT_ID_CONFIG;
-import static com.couchbase.connect.kafka.CouchbaseSinkConnectorConfig.REPLICATE_TO_CONFIG;
-import static com.couchbase.connect.kafka.CouchbaseSinkConnectorConfig.SUBDOCUMENT_MODE_CONFIG;
+import static com.couchbase.connect.kafka.CouchbaseSinkConnectorConfig.*;
 import static com.couchbase.connect.kafka.CouchbaseSourceConnector.setForceIpv4;
 import static com.couchbase.connect.kafka.CouchbaseSourceConnectorConfig.FORCE_IPV4_CONFIG;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -93,6 +82,8 @@ public class CouchbaseSinkTask extends SinkTask {
 
     private N1qlWriter n1qlWriter;
     private N1qlMode n1qlMode;
+    private N1qlClause n1qlClause;
+    private List<String> n1qlClauseFields;
 
     private boolean createPaths;
     private boolean createDocuments;
@@ -171,7 +162,10 @@ public class CouchbaseSinkTask extends SinkTask {
             case N1QL: {
                 n1qlMode = config.getEnum(N1qlMode.class, N1QL_MODE_CONFIG);
                 createDocuments = config.getBoolean(CouchbaseSinkConnectorConfig.SUBDOCUMENT_CREATEDOCUMENT_CONFIG);
-                n1qlWriter = new N1qlWriter(n1qlMode, createDocuments);
+                n1qlClause = config.getEnum(N1qlClause.class, N1QL_CLAUSE_CONFIG);
+                n1qlClauseFields = config.getList(N1QL_CLAUSE_FIELDS_CONFIG);
+
+                n1qlWriter = new N1qlWriter(n1qlMode, n1qlClause, n1qlClauseFields, createDocuments);
                 break;
             }
         }

--- a/src/main/java/com/couchbase/connect/kafka/sink/N1qlClause.java
+++ b/src/main/java/com/couchbase/connect/kafka/sink/N1qlClause.java
@@ -1,0 +1,6 @@
+package com.couchbase.connect.kafka.sink;
+
+public enum N1qlClause {
+    KEYS,
+    WHERE
+}

--- a/src/main/java/com/couchbase/connect/kafka/sink/N1qlWriter.java
+++ b/src/main/java/com/couchbase/connect/kafka/sink/N1qlWriter.java
@@ -140,18 +140,27 @@ public class N1qlWriter {
         String result = statement.toString();
         StringBuilder condition = new StringBuilder();
         for (String name : clause_fields) {
-            if(clause_fields.indexOf(name) == clause_fields.size()-1) {
-                condition.append(String.format("`%s` = $%s", name, name));
-            }
-            else {
-                condition.append(String.format("`%s` = $%s AND ", name, name));
-            }
+            appendClause(condition, name,clause_fields.indexOf(name) == clause_fields.size()-1);
         }
 
         return result.substring(0, result.length() - 2) + " WHERE " + condition.toString() +" RETURNING meta().id;";
     }
 
+    private void appendClause(StringBuilder condition, String name,  boolean last)
+    {
+        String operator = last ? "" : " AND ";
+        if(name.contains(":")){
+            String[] staticValues = name.split(":",2);
+            if(staticValues.length == 2) {
+                condition.append(String.format("`%s` = '%s'%s", staticValues[0], staticValues[1], operator));
+            }
+        }
+        else {
 
+            condition.append(String.format("`%s` = $%s%s", name, name, operator));
+        }
+    }
+    
     private String parseUpsert(String keySpace, JsonObject values) {
         if (values == null || values.equals(JsonObject.empty())) {
             return null;

--- a/src/test/java/com/couchbase/connect/kafka/sink/N1qlWriterTest.java
+++ b/src/test/java/com/couchbase/connect/kafka/sink/N1qlWriterTest.java
@@ -146,6 +146,43 @@ public class N1qlWriterTest {
 
 
     @Test
+    public void generateStatementWithConditionAndStaticValueAtEnd() {
+        JsonObject object = JsonObject.empty().put("test", "string");
+
+        List<String> fields = new ArrayList<String>();
+        fields.add("styleNumber");
+        fields.add("documentType:option");
+        write(object, N1qlMode.UPDATE, N1qlClause.WHERE, fields, emptyResult);
+
+        verify(bucket).query(argument.capture());
+
+        ParameterizedN1qlQuery query = (ParameterizedN1qlQuery) argument.getValue();
+
+        assertNotNull(query);
+        assertEquals("UPDATE `default` SET `test` = $test WHERE `styleNumber` = $styleNumber AND `documentType` = 'option' RETURNING meta().id;", query.statement().toString());
+        assertEquals(object.put("__id__", "id"), query.statementParameters());
+    }
+
+    @Test
+    public void generateStatementWithConditionAndStaticValueAtStart() {
+        JsonObject object = JsonObject.empty().put("test", "string");
+
+        List<String> fields = new ArrayList<String>();
+        fields.add("documentType:option");
+        fields.add("styleNumber");
+
+        write(object, N1qlMode.UPDATE, N1qlClause.WHERE, fields, emptyResult);
+
+        verify(bucket).query(argument.capture());
+
+        ParameterizedN1qlQuery query = (ParameterizedN1qlQuery) argument.getValue();
+
+        assertNotNull(query);
+        assertEquals("UPDATE `default` SET `test` = $test WHERE `documentType` = 'option' AND `styleNumber` = $styleNumber RETURNING meta().id;", query.statement().toString());
+        assertEquals(object.put("__id__", "id"), query.statementParameters());
+    }
+
+    @Test
     public void doesNotCreateDocumentWhenUpdateReturns1Row() {
 
         DefaultAsyncN1qlQueryRow row = new DefaultAsyncN1qlQueryRow(new byte[0]);


### PR DESCRIPTION
this is the opposite of the other PR where you can update multiple documents with one message. consider the following data

```
{"id":"airline_1", "type":"airline", "name":"airline 1", "parent_companycode":"AA", "parent_companyname":"airline inc"}
{"id":"airline_2", "type":"airline", "name":"airline 2", "parent_companycode":"AA", "parent_companyname":"airline inc"}
{"id":"airline_3", "type":"airline", "name":"airline 3", "parent_companycode":"AA", "parent_companyname":"airline inc"}
```
in the current situation, if we would want to update the parent_companyname we need to send and process three messages based on the id. 

this PR allows you to send one message and match it on something else than the id. if you would configure the plugin as follows:

```
...
"couchbase.document.mode":"N1QL",
"couchbase.n1ql.operation":"UPDATE",
"couchbase.n1ql.clause":"WHERE",		
"couchbase.n1ql.clause.fields":"type,parent_companycode"
...
```
the connector will generate an update statement with a WHERE clause instead of ON KEYS.  for example, if a message would look like this:
```
{"type":"airline",  "parent_companycode":"AA", "parent_companyname":"airline ltd"}
```
if would generate a statement along the lines of

```
UPDATE `keyspace` 
SET `parent_companyname` = $parent_companyname
WHERE  `type` = $type AND `parent_companycode` = $parent_companycode
RETURNING meta().id
```
i intentionally made the where clause very simple (so no boolean logic or injected where clause to avoid any n1ql injection issues but this is a proposal and i am willing to change this anyway you want if this is something that you would want to add to the connector.