### PR TITLE
MINOR - Optimize Memory Allocations For sourcePartitions

### DIFF
--- a/src/main/java/com/couchbase/connect/kafka/CouchbaseSourceTask.java
+++ b/src/main/java/com/couchbase/connect/kafka/CouchbaseSourceTask.java
@@ -283,7 +283,7 @@ public class CouchbaseSourceTask extends SourceTask {
   }
 
   private List<Map<String, Object>> sourcePartitions(Short[] partitions) {
-    List<Map<String, Object>> sourcePartitions = new ArrayList<>();
+    List<Map<String, Object>> sourcePartitions = new ArrayList<>(partitions.length);
     for (Short partition : partitions) {
       sourcePartitions.add(sourcePartition(partition));
     }


### PR DESCRIPTION
Set the initial capacity of the ArrayList to the known
size. Simple, but effective enhancement for a method
in the hot path.