### PR TITLE
Topic to document Id feature is added 

### DIFF
--- a/src/main/java/com/couchbase/connect/kafka/config/sink/SinkBehaviorConfig.java
+++ b/src/main/java/com/couchbase/connect/kafka/config/sink/SinkBehaviorConfig.java
@@ -72,6 +72,22 @@ public interface SinkBehaviorConfig {
   @Default
   List<String> topicToCollection();
   
+  /**
+   * A map from Kafka topic to Document Id of Couchbase collection.
+   * <p>
+   * Topic and document id are joined by an equals sign.
+   * Map entries are delimited by commas.
+   * <p>
+   * A document id is of the form `/column_id` or `/field/column_id`.
+   * <p>
+   * For example, if you want to pick document id from topic "topic1"
+   * to document id "id" in the message, and document id from topic "topic2"
+   * to document id "field.column_id" in the message you would write:
+   * "topic1=/id,topic2=/field/column_id".
+   * <p>
+   * Defaults to an empty map, with all messages going to the collection
+   * as document id of specified by `couchbase.document.id`.
+   */
   @Default
   List<String> topicToDocumentId();
 

--- a/src/main/java/com/couchbase/connect/kafka/config/sink/SinkBehaviorConfig.java
+++ b/src/main/java/com/couchbase/connect/kafka/config/sink/SinkBehaviorConfig.java
@@ -71,6 +71,9 @@ public interface SinkBehaviorConfig {
    */
   @Default
   List<String> topicToCollection();
+  
+  @Default
+  List<String> topicToDocumentId();
 
   @SuppressWarnings("unused")
   static ConfigDef.Validator topicToCollectionValidator() {

--- a/src/main/java/com/couchbase/connect/kafka/util/TopicMap.java
+++ b/src/main/java/com/couchbase/connect/kafka/util/TopicMap.java
@@ -36,6 +36,12 @@ public class TopicMap {
   ) {
     return mapValues(parseCommon(topicToCollection), it -> Keyspace.parse(it, defaultBucket));
   }
+  
+  public static Map<String, String> parseTopicToDcumentId(
+		  List<String> topicToDocumentId) {
+	  
+	  return parseCommon(topicToDocumentId);
+  }
 
   public static Map<ScopeAndCollection, String> parseCollectionToTopic(List<String> collectionToTopic) {
     return mapKeys(parseCommon(collectionToTopic), ScopeAndCollection::parse);


### PR DESCRIPTION
This is a reference to the issue/enhancement raised by me 
https://github.com/couchbase/kafka-connect-couchbase/issues/39 

I enabled a new property in config called couchbase.topic.to.document.id. This will let setting document Id for each topic just like couchbase.topic.to.collection allows to map each topic to different collection. 

Should you any feedback or clarifications, please revert. 