### PR TITLE
Adding capability to propagate producer publish to topic acknowledgment via SourceHandler

### DIFF
--- a/src/main/java/com/couchbase/connect/kafka/CouchbaseSourceTask.java
+++ b/src/main/java/com/couchbase/connect/kafka/CouchbaseSourceTask.java
@@ -312,11 +312,10 @@ public class CouchbaseSourceTask extends SourceTask {
       CouchbaseSourceRecord couchbaseRecord = (CouchbaseSourceRecord) record;
       if (isSourceOffsetUpdate(couchbaseRecord)) {
         lifecycle.logSourceOffsetUpdateCommittedToBlackHoleTopic(couchbaseRecord, metadata);
-        sourceHandler.recordCommited(record, metadata, true);
       } else {
         lifecycle.logCommittedToKafkaTopic(couchbaseRecord, metadata);
-        sourceHandler.recordCommited(record, metadata, false);
       }
+      sourceHandler.recordCommited(record, metadata);
     } else {
       LOGGER.warn("Committed a record we didn't create? Record key {}", record.key());
     }

--- a/src/main/java/com/couchbase/connect/kafka/CouchbaseSourceTask.java
+++ b/src/main/java/com/couchbase/connect/kafka/CouchbaseSourceTask.java
@@ -312,8 +312,10 @@ public class CouchbaseSourceTask extends SourceTask {
       CouchbaseSourceRecord couchbaseRecord = (CouchbaseSourceRecord) record;
       if (isSourceOffsetUpdate(couchbaseRecord)) {
         lifecycle.logSourceOffsetUpdateCommittedToBlackHoleTopic(couchbaseRecord, metadata);
+        sourceHandler.recordCommited(record, metadata, true);
       } else {
         lifecycle.logCommittedToKafkaTopic(couchbaseRecord, metadata);
+        sourceHandler.recordCommited(record, metadata, false);
       }
     } else {
       LOGGER.warn("Committed a record we didn't create? Record key {}", record.key());

--- a/src/main/java/com/couchbase/connect/kafka/handler/source/SourceHandler.java
+++ b/src/main/java/com/couchbase/connect/kafka/handler/source/SourceHandler.java
@@ -18,6 +18,9 @@ package com.couchbase.connect.kafka.handler.source;
 
 import java.util.Map;
 
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.connect.source.SourceRecord;
+
 /**
  * Primary extension point for customizing how the Source Connector publishes messages to Kafka.
  */
@@ -29,6 +32,18 @@ public interface SourceHandler {
    */
   default void init(Map<String, String> configProperties) {
   }
+
+  /**
+   * Function called as acknowledgement of a SourceRecord being published to a Kafka topic, propagated from Kafka Connect SourceTask.commitRecord().
+   * SourceHandlers are not required to implement this function, by default it is a no-op.
+   * 
+   * @param sourceRecord {@link SourceRecord} that was successfully sent via the producer or filtered by a transformation
+   * @param recordMetadata {@link RecordMetadata} record metadata returned from the broker, or null if the record was filtered
+   * @param isBlackHole boolean indicating whether the topic is a black hole topic (ignored events) [true] or regular topic [false]
+   */
+  default void recordCommited(SourceRecord sourceRecord, RecordMetadata recordMetadata, boolean isBlackHole) {
+      
+  } 
 
   /**
    * Translates a DocumentEvent into a SourceRecord for publication to a Kafka topic.

--- a/src/main/java/com/couchbase/connect/kafka/handler/source/SourceHandler.java
+++ b/src/main/java/com/couchbase/connect/kafka/handler/source/SourceHandler.java
@@ -21,6 +21,8 @@ import java.util.Map;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.connect.source.SourceRecord;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Primary extension point for customizing how the Source Connector publishes messages to Kafka.
  */
@@ -36,12 +38,12 @@ public interface SourceHandler {
   /**
    * Function called as acknowledgement of a SourceRecord being published to a Kafka topic, propagated from Kafka Connect SourceTask.commitRecord().
    * SourceHandlers are not required to implement this function, by default it is a no-op.
-   * 
+   *  
    * @param sourceRecord {@link SourceRecord} that was successfully sent via the producer or filtered by a transformation
    * @param recordMetadata {@link RecordMetadata} record metadata returned from the broker, or null if the record was filtered
-   * @param isBlackHole boolean indicating whether the topic is a black hole topic (ignored events) [true] or regular topic [false]
+   * 
    */
-  default void recordCommited(SourceRecord sourceRecord, RecordMetadata recordMetadata, boolean isBlackHole) {
+  default void recordCommited(SourceRecord sourceRecord, @Nullable RecordMetadata recordMetadata) {
       
   } 
 


### PR DESCRIPTION
Added recordCommited default function to SourceHandler interface and call from CouchbaseSourceTask to allow propagating commitRecord ACK on published records in custom implementations.
Default function is no-op. 